### PR TITLE
fix: ensure TX log entry appears before RX in console

### DIFF
--- a/src/hooks/useCommandExecution.ts
+++ b/src/hooks/useCommandExecution.ts
@@ -315,9 +315,10 @@ export function useCommandExecution(
         dataBytes = newData;
       }
 
-      await write(activeSessionId, dataBytes);
-      // Pass command parameters to log
+      // Log TX before write to ensure correct chronological ordering
+      // (echo devices respond immediately, RX would appear before TX otherwise)
       addLog(dataBytes, "TX", cmdInfo?.contextIds, activeSessionId, params);
+      await write(activeSessionId, dataBytes);
 
       // System Log
       const displayPayload =


### PR DESCRIPTION
## Summary
- Moved `addLog` call for TX to before `await write()` to ensure correct chronological ordering
- Previously, echo devices would respond immediately, causing RX to be logged before TX completed

## Root Cause
The TX log was being added after `await write()` completed. But mock/echo devices echo data back immediately during the write, so the RX log was added (with an earlier timestamp) before the TX log was added.

## Test plan
- [ ] Connect to "Virtual Echo Device" port
- [ ] Send a message (e.g., "Hello World Test")
- [ ] Verify TX entry appears before RX in Console Log List view
- [ ] Verify TX timestamp is earlier than RX timestamp

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)