### PR TITLE
fix: provide fallback values for Logic View slider min/max

### DIFF
--- a/src/components/console/LogicAnalyzerPanel.tsx
+++ b/src/components/console/LogicAnalyzerPanel.tsx
@@ -800,8 +800,8 @@ const LogicAnalyzerPanel: React.FC<{ logs: LogEntry[] }> = ({ logs }) => {
               stroke="#3b82f6"
               fill="transparent"
               tickFormatter={() => ""}
-              startIndex={domain?.min}
-              endIndex={domain?.max}
+              startIndex={domain?.min ?? 0}
+              endIndex={domain?.max ?? Math.max(0, chartData.length - 1)}
               onChange={handleBrushChange}
               alwaysShowText={false}
               className="text-[9px] [&_.recharts-brush-slide]:fill-zinc-200/50 dark:[&_.recharts-brush-slide]:fill-zinc-700/50 [&_.recharts-brush-traveller]:fill-zinc-400 dark:[&_.recharts-brush-traveller]:fill-zinc-500"


### PR DESCRIPTION
## Summary
- Added nullish coalescing (`??`) to provide default values when `domain` is null
- `startIndex` defaults to `0`
- `endIndex` defaults to `Math.max(0, chartData.length - 1)`

## Root Cause
The `Brush` component from recharts was receiving `undefined` for `startIndex` and `endIndex` when `domain` was null, causing accessibility attributes to show "Min value: undefined, Max value: undefined".

## Test plan
- [ ] Connect to any virtual device
- [ ] Send some data to generate TX/RX entries
- [ ] Switch to "Logic" view
- [ ] Verify the slider at the bottom shows proper numeric values (not undefined)

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)