### PR TITLE
fix: remove excessive console logging in useFraming.ts

### DIFF
--- a/src/hooks/useFraming.ts
+++ b/src/hooks/useFraming.ts
@@ -110,7 +110,6 @@ export function useFraming() {
     onValidate?: (data: Uint8Array, sessionId: string, logId: string) => void,
   ) => {
     return (chunk: Uint8Array) => {
-      console.log(`[${sessionId}] Data received:`, chunk);
       let framer = framersRef.current.get(sessionId);
 
       const session = useStore.getState().sessions[sessionId];


### PR DESCRIPTION
## Summary
- Removed debug `console.log` that was firing on every data chunk received
- This was causing console flooding and performance issues during continuous data streaming

## Root Cause
A debug logging statement in `handleDataReceived` was logging every single incoming data chunk, resulting in hundreds of log entries per second when connected to continuous streaming devices.

## Test plan
- [ ] Connect to "Virtual Sine Wave Generator" or similar streaming device
- [ ] Open browser Developer Tools → Console
- [ ] Verify console is no longer flooded with data received logs
- [ ] Confirm data reception still works correctly (check Console Log view)

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)