### PR TITLE
fix: guard against NaN values in Logic View SVG rendering

### DIFF
--- a/src/components/console/LogicAnalyzerPanel.tsx
+++ b/src/components/console/LogicAnalyzerPanel.tsx
@@ -94,6 +94,9 @@ const ByteAnnotations: React.FC<ByteAnnotationsProps> = ({
   const rxLineY = yScale(RX_HIGH) - 20;
   const txLineY = yScale(TX_HIGH) - 20;
 
+  // Guard against NaN values in Y calculations
+  if (!Number.isFinite(rxLineY) || !Number.isFinite(txLineY)) return null;
+
   return (
     <g className="byte-annotations">
       {visibleAnnotations.map((anno, idx) => {
@@ -103,6 +106,15 @@ const ByteAnnotations: React.FC<ByteAnnotationsProps> = ({
         const lineY = anno.channel === "RX" ? rxLineY : txLineY;
         const color = anno.channel === "RX" ? RX_COLOR : TX_COLOR;
         const colorFaded = anno.channel === "RX" ? "#10b98140" : "#3b82f640";
+
+        // Skip rendering if any coordinate is NaN
+        if (
+          !Number.isFinite(xStart) ||
+          !Number.isFinite(xEnd) ||
+          !Number.isFinite(xMid)
+        ) {
+          return null;
+        }
 
         return (
           <g key={`anno-${anno.channel}-${idx}`}>


### PR DESCRIPTION
## Summary
- Added `Number.isFinite()` checks before rendering SVG elements
- Guards against NaN Y coordinates (`rxLineY`, `txLineY`)
- Skips rendering individual annotations when X coordinates are NaN

## Root Cause
The scale functions could return NaN when the axis domain wasn't properly initialized, or when annotation index values were invalid. This caused React DOM errors about invalid SVG attribute values.

## Test plan
- [ ] Connect to a streaming device (e.g., Virtual Sine Wave Generator)
- [ ] Switch to Logic view
- [ ] Open browser DevTools console
- [ ] Verify no NaN-related SVG errors appear
- [ ] Verify waveform visualization still renders correctly

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)