### PR TITLE
fix: resolve button nesting in StructuresTab

### DIFF
--- a/src/pages/ProtocolEditor/tabs/StructuresTab.tsx
+++ b/src/pages/ProtocolEditor/tabs/StructuresTab.tsx
@@ -136,11 +136,21 @@ export const StructuresTab: React.FC<StructuresTabProps> = ({
               key={structure.id}
               className="border border-border rounded-lg overflow-hidden"
             >
-              <button
+              <div
+                role="button"
+                tabIndex={0}
                 onClick={() =>
                   setExpanded(expanded === structure.id ? null : structure.id)
                 }
-                className="w-full flex items-center gap-3 p-4 text-left hover:bg-muted/50"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setExpanded(
+                      expanded === structure.id ? null : structure.id,
+                    );
+                  }
+                }}
+                className="w-full flex items-center gap-3 p-4 text-left hover:bg-muted/50 cursor-pointer"
               >
                 {expanded === structure.id ? (
                   <ChevronDown className="w-4 h-4" />
@@ -176,7 +186,7 @@ export const StructuresTab: React.FC<StructuresTabProps> = ({
                 >
                   <Trash2 className="w-4 h-4 text-destructive" />
                 </Button>
-              </button>
+              </div>
               {expanded === structure.id && (
                 <div className="border-t border-border p-4 bg-muted/30">
                   <div className="flex items-center justify-between mb-3">


### PR DESCRIPTION
## Summary
- Changed structure row from `<button>` to `<div>` with `role="button"` to fix invalid HTML nesting
- Added proper keyboard accessibility with `tabIndex` and `onKeyDown` handler for Enter/Space keys
- Added `cursor-pointer` class for visual consistency

## Test plan
- [ ] Navigate to Protocol Editor → Structures tab
- [ ] Create a new structure
- [ ] Verify no console errors about button nesting
- [ ] Verify clicking structure row still toggles expansion
- [ ] Verify keyboard navigation (Tab to row, Enter/Space to toggle) works
- [ ] Verify Edit/Delete buttons still work

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)