### PR TITLE
fix(session): ensure disconnect updates correct session state

### DIFF
--- a/src/lib/slices/sessionSlice.ts
+++ b/src/lib/slices/sessionSlice.ts
@@ -116,8 +116,8 @@ export interface SessionSliceActions {
     updater: NetworkConfig | ((prev: NetworkConfig) => NetworkConfig),
   ) => void;
   setConnectionType: (type: "SERIAL" | "NETWORK") => void;
-  setIsConnected: (connected: boolean) => void;
-  setPortName: (name: string) => void;
+  setIsConnected: (connected: boolean, sessionId?: string) => void;
+  setPortName: (name: string, sessionId?: string) => void;
 
   setInputBuffer: (buffer: string) => void;
   setSendMode: (mode: DataMode) => void;
@@ -248,11 +248,31 @@ export const createSessionSlice: StateCreator<
   setConnectionType: (type) =>
     set((state) => updateActiveSession(state, { connectionType: type })),
 
-  setIsConnected: (connected) =>
-    set((state) => updateActiveSession(state, { isConnected: connected })),
+  setIsConnected: (connected, sessionId) =>
+    set((state) => {
+      const targetId = sessionId || state.activeSessionId;
+      const session = state.sessions[targetId];
+      if (!session) return {};
+      return {
+        sessions: {
+          ...state.sessions,
+          [targetId]: { ...session, isConnected: connected },
+        },
+      };
+    }),
 
-  setPortName: (name) =>
-    set((state) => updateActiveSession(state, { portName: name })),
+  setPortName: (name, sessionId) =>
+    set((state) => {
+      const targetId = sessionId || state.activeSessionId;
+      const session = state.sessions[targetId];
+      if (!session) return {};
+      return {
+        sessions: {
+          ...state.sessions,
+          [targetId]: { ...session, portName: name },
+        },
+      };
+    }),
 
   setInputBuffer: (buffer) =>
     set((state) => updateActiveSession(state, { inputBuffer: buffer })),


### PR DESCRIPTION
## Summary
- Fixed CLOSE PORT button not properly updating UI state to reflect disconnection
- Modified `setIsConnected` and `setPortName` to accept optional `sessionId` parameter
- Updated `MainWorkspace` handlers to explicitly pass `sessionId` to ensure correct session is updated

## Root Cause
The `setIsConnected` and `setPortName` functions only updated the session based on `state.activeSessionId`. During async disconnect operations, if the user switched sessions or if there was any state change, the wrong session could be updated. The fix ensures the specific session being connected/disconnected is always targeted explicitly.

## Changes
- `src/lib/slices/sessionSlice.ts`: Added optional `sessionId` parameter to `setIsConnected` and `setPortName`
- `src/pages/MainWorkspace.tsx`: Updated `onConnect` and `onDisconnect` handlers to capture and pass sessionId explicitly

## Test plan
- [ ] Connect to a virtual device (e.g., Virtual Sine Wave Generator)
- [ ] Verify data flows and status shows "Connected"
- [ ] Click CLOSE PORT button
- [ ] Verify status changes to "Disconnected/Offline"
- [ ] Verify OPEN PORT button appears instead of CLOSE PORT
- [ ] Verify serial configuration controls become enabled

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>