### PR TITLE
fix(sidebar): replace Link + IconButton nesting with styled Links

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -427,15 +427,13 @@ const Sidebar: React.FC<Props> = ({ onSendCommand, onRunSequence }) => {
                   className="flex items-center gap-1"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <Link to="/devices">
-                    <IconButton
-                      variant="ghost"
-                      size="xs"
-                      aria-label="Open Device Library"
-                      title="Open Device Library"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5" />
-                    </IconButton>
+                  <Link
+                    to="/devices"
+                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label="Open Device Library"
+                    title="Open Device Library"
+                  >
+                    <ExternalLink className="w-4 h-4" />
                   </Link>
                   <IconButton
                     variant="ghost"
@@ -537,15 +535,13 @@ const Sidebar: React.FC<Props> = ({ onSendCommand, onRunSequence }) => {
                   className="flex items-center gap-1"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <Link to="/protocols">
-                    <IconButton
-                      variant="ghost"
-                      size="xs"
-                      aria-label="Open Protocol Library"
-                      title="Open Protocol Library"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5" />
-                    </IconButton>
+                  <Link
+                    to="/protocols"
+                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label="Open Protocol Library"
+                    title="Open Protocol Library"
+                  >
+                    <ExternalLink className="w-4 h-4" />
                   </Link>
                   <IconButton
                     variant="ghost"
@@ -605,15 +601,13 @@ const Sidebar: React.FC<Props> = ({ onSendCommand, onRunSequence }) => {
                   className="flex items-center gap-1"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <Link to="/commands">
-                    <IconButton
-                      variant="ghost"
-                      size="xs"
-                      aria-label="Open Command Library"
-                      title="Open Command Library"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5" />
-                    </IconButton>
+                  <Link
+                    to="/commands"
+                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label="Open Command Library"
+                    title="Open Command Library"
+                  >
+                    <ExternalLink className="w-4 h-4" />
                   </Link>
                   <IconButton
                     variant="ghost"
@@ -837,15 +831,13 @@ const Sidebar: React.FC<Props> = ({ onSendCommand, onRunSequence }) => {
                   className="flex items-center gap-1"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <Link to="/sequences">
-                    <IconButton
-                      variant="ghost"
-                      size="xs"
-                      aria-label="Open Sequence Library"
-                      title="Open Sequence Library"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5" />
-                    </IconButton>
+                  <Link
+                    to="/sequences"
+                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                    aria-label="Open Sequence Library"
+                    title="Open Sequence Library"
+                  >
+                    <ExternalLink className="w-4 h-4" />
                   </Link>
                   <IconButton
                     variant="ghost"


### PR DESCRIPTION
## Summary
- Fixed protocol pages (and other library pages) not rendering when navigating from sidebar
- Root cause was invalid HTML: `<a><button></button></a>` - buttons nested inside anchor elements
- Replaced all `<Link><IconButton>...</IconButton></Link>` patterns with properly styled `<Link>` elements

## Root Cause
The sidebar's library navigation links (Devices, Protocols, Commands, Sequences) used a pattern of wrapping `IconButton` components inside React Router `Link` components. This created invalid HTML structure:
- `Link` renders as `<a>` (anchor)
- `IconButton` renders as `<button>`
- Result: `<a><button>...</button></a>` - invalid per HTML spec

When clicking these invalid nested elements:
1. The browser's click handling was inconsistent
2. The URL would change (router detected the click)
3. But the React component tree didn't properly re-render

## Changes
- `src/components/Sidebar.tsx`: Replaced 4 instances of `Link > IconButton` with `Link` elements that have the icon button styling applied directly via className

## Test plan
- [ ] Click "Open Protocol Library" (external link icon) in Protocols section - should navigate to `/protocols`
- [ ] Click "Open Device Library" (external link icon) in Devices section - should navigate to `/devices`
- [ ] Click "Open Command Library" (external link icon) in Commands section - should navigate to `/commands`
- [ ] Click "Open Sequence Library" (external link icon) in Sequences section - should navigate to `/sequences`
- [ ] Click on a protocol name (e.g., "AT Commands") - should navigate to protocol editor
- [ ] Verify page content renders correctly (not just URL change)

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>