### PR TITLE
fix(command-library): actually save new commands in onSave callback

### DIFF
--- a/src/pages/CommandLibrary.tsx
+++ b/src/pages/CommandLibrary.tsx
@@ -38,6 +38,7 @@ const CommandLibrary: React.FC = () => {
     setEditingCommand,
     editingCommand,
     setContexts,
+    addToast,
   } = useStore();
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -273,7 +274,13 @@ const CommandLibrary: React.FC = () => {
           initialData={editingCommand || undefined}
           sequences={sequences}
           contexts={contexts}
-          onSave={() => {
+          onSave={(command) => {
+            addCommand(command);
+            addToast(
+              "success",
+              "Command Saved",
+              `Command "${command.name}" has been saved.`,
+            );
             setShowAddModal(false);
             setEditingCommand(null);
           }}


### PR DESCRIPTION
## Summary
- Fixed new commands not being saved when creating them from Command Library page
- Added success toast notification for user feedback

## Root Cause
The `onSave` callback in `CommandLibrary.tsx` was only closing the modal without calling `addCommand()` to persist the command data:
```jsx
// Before (broken)
onSave={() => {
  setShowAddModal(false);
  setEditingCommand(null);
}}
```

## Changes
- `src/pages/CommandLibrary.tsx`: Added `addCommand(command)` call and success toast in onSave callback

## Test plan
- [ ] Navigate to Command Library (/commands)
- [ ] Click "New Command" button
- [ ] Fill in command details and click Save
- [ ] Verify success toast appears
- [ ] Verify command appears in the list
- [ ] Verify command count increases

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>