### PR TITLE
fix: prevent TCP mode from triggering WebSerial port chooser

### DIFF
--- a/src/pages/MainWorkspace.tsx
+++ b/src/pages/MainWorkspace.tsx
@@ -352,6 +352,7 @@ const MainWorkspace: React.FC = () => {
                   activeSessionId,
                   config,
                   networkConfig,
+                  connectionType,
                   port,
                 );
                 setIsConnected(true);

--- a/src/tests/hooks/useSerialConnection.test.ts
+++ b/src/tests/hooks/useSerialConnection.test.ts
@@ -71,6 +71,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -88,6 +89,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -112,12 +114,14 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
         await result.current.connect(
           "session-2",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -143,6 +147,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -155,6 +160,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -175,6 +181,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -223,12 +230,14 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
         await result.current.connect(
           "session-2",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -264,6 +273,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -295,6 +305,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -329,18 +340,21 @@ describe("useSerialConnection", () => {
           "session-A",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
         await result.current.connect(
           "session-B",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
         await result.current.connect(
           "session-C",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -368,12 +382,14 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
         await result.current.connect(
           "session-2",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });
@@ -427,6 +443,7 @@ describe("useSerialConnection", () => {
           "session-1",
           defaultConfig,
           defaultNetworkConfig,
+          "SERIAL",
           "mock-echo",
         );
       });


### PR DESCRIPTION
## Summary
- Add `connectionType` parameter to `connect()` function in `useSerialConnection` hook
- Check `connectionType` first to properly route to network connection without triggering WebSerial
- Update test file to include new parameter

## Root Cause
When connecting in TCP mode, the `connect()` function would check `serialService.isSupported()` and if true (which it is in Chrome/Edge), would trigger the browser's serial port chooser dialog instead of using the network/WebSocket connection.

## Solution
Added explicit `connectionType` parameter ("SERIAL" | "NETWORK") to the connect function and restructured the logic to check this parameter first, ensuring TCP mode always uses NetworkPort.

## Test plan
- [x] All 362 tests pass
- [ ] Manual test: Switch to TCP mode, click Connect - should not show port chooser
- [ ] Manual test: Serial mode continues to work as expected

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)