### PR TITLE
Fix spacing between console message list and input panel

### DIFF
--- a/src/components/ConsoleViewer.tsx
+++ b/src/components/ConsoleViewer.tsx
@@ -214,7 +214,7 @@ const ConsoleViewer: React.FC = () => {
 
           <div
             className={cn(
-              "flex flex-col w-full mx-auto",
+              "flex flex-col w-full mx-auto pb-8",
               view === "list" ? "max-w-5xl" : "w-full max-w-[98%] items-center",
             )}
           >


### PR DESCRIPTION
## Summary

- Adds bottom padding to the console message list container to create proper spacing between the last message and the input panel

## Problem

The message list's bottom was too close to the input panel toolbar, making the UI feel cramped.

## Solution

Added `pb-8` (32px bottom padding) to the message list container in `ConsoleViewer.tsx`.

## Test plan

- [ ] Open the console view
- [ ] Send/receive some messages
- [ ] Verify there is adequate spacing between the last message and the input panel toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)