### PR TITLE
fix(ci): correct rust-toolchain action name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install Rust stable
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
Fix typo: dtolnay/rust-action -> dtolnay/rust-toolchain

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)