### PR TITLE
fix(rust): rename _app to app in setup_logging

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,7 +27,8 @@ use tracing_subscriber::fmt::time::OffsetTime;
 
 use crate::state::AppState;
 
-pub fn setup_logging(_app: &tauri::App) {
+#[allow(unused_variables)]
+pub fn setup_logging(app: &tauri::App) {
     let fmt = if cfg!(debug_assertions) {
         format_description!("[hour]:[minute]:[second].[subsecond digits:3]")
     } else {


### PR DESCRIPTION
## Summary
Fix Rust compilation error in release builds caused by parameter name mismatch.

The `setup_logging` function parameter was named `_app` but the code in the release-only block (`#[cfg(all(desktop, not(debug_assertions)))]`) referenced it as `app`, causing builds to fail.

## Test plan
- [ ] Build workflow passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)