### PR TITLE
fix: add permissions for release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary
- Add `contents: write` permission to the build workflow

## Root Cause
The release job was failing with:
```
Resource not accessible by integration
```

By default, `GITHUB_TOKEN` has read-only permissions. The `softprops/action-gh-release@v2` action needs write access to:
- Create/update GitHub releases
- Upload release assets
- Generate release notes

## Test plan
- [x] Merge this PR
- [ ] Delete and recreate v0.0.0 tag
- [ ] Verify release job succeeds and uploads artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)