### PR TITLE
refactor: split CommandFormModal into focused tab components

### DIFF
--- a/src/components/CommandForm/BasicTab.tsx
+++ b/src/components/CommandForm/BasicTab.tsx
@@ -1,0 +1,652 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  Check,
+  AlertTriangle,
+  Layers,
+  FileCode,
+  Cpu,
+  ExternalLink,
+  Info,
+} from "lucide-react";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { Textarea } from "../ui/Textarea";
+import { Label } from "../ui/Label";
+import { SelectDropdown } from "../ui/Select";
+import { CardContent } from "../ui/Card";
+import { Badge } from "../ui/Badge";
+import { Checkbox } from "../ui/Checkbox";
+import { cn } from "../../lib/utils";
+import { substituteParameters } from "../../lib/commandBuilder";
+import type { DropdownOption } from "../ui/Dropdown";
+import type { DataMode, TextEncoding } from "../../types";
+import type {
+  Protocol,
+  SimpleCommand,
+  SimpleParameter,
+} from "../../lib/protocolTypes";
+import type { Device } from "../../types";
+
+interface BasicTabProps {
+  // Name & Group
+  name: string;
+  onNameChange: (name: string) => void;
+  group: string;
+  onGroupChange: (group: string) => void;
+  // Device & Protocol
+  deviceId: string;
+  onDeviceIdChange: (id: string) => void;
+  protocolId: string;
+  onProtocolIdChange: (id: string) => void;
+  devices: Device[];
+  availableProtocols: Protocol[];
+
+  // Command source
+  source: "CUSTOM" | "PROTOCOL";
+  onSourceChange: (source: "CUSTOM" | "PROTOCOL") => void;
+  templateId: string;
+  onTemplateIdChange: (id: string) => void;
+  availableTemplates: SimpleCommand[];
+  selectedTemplate: SimpleCommand | undefined;
+  parameterValues: Record<string, unknown>;
+  onParameterValuesChange: React.Dispatch<
+    React.SetStateAction<Record<string, unknown>>
+  >;
+  protocols: Protocol[];
+
+  // Custom command fields
+  mode: DataMode;
+  onModeChange: (mode: DataMode) => void;
+  encoding: TextEncoding;
+  onEncodingChange: (encoding: TextEncoding) => void;
+  payload: string;
+  onPayloadChange: (payload: string) => void;
+
+  // i18n
+  t: (key: string) => string;
+}
+
+const BasicTab: React.FC<BasicTabProps> = ({
+  name,
+  onNameChange,
+  group,
+  onGroupChange,
+  deviceId,
+  onDeviceIdChange,
+  protocolId,
+  onProtocolIdChange,
+  devices,
+  availableProtocols,
+  source,
+  onSourceChange,
+  templateId,
+  onTemplateIdChange,
+  availableTemplates,
+  selectedTemplate,
+  parameterValues,
+  onParameterValuesChange,
+  protocols,
+  mode,
+  onModeChange,
+  encoding,
+  onEncodingChange,
+  payload,
+  onPayloadChange,
+  t,
+}) => {
+  return (
+    <CardContent className="pt-6 space-y-4">
+      {/* Device & Protocol Selection */}
+      <div className="p-4 bg-muted/20 rounded-lg border border-border/50 space-y-4">
+        <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground uppercase">
+          <Layers className="w-3.5 h-3.5" />
+          Device & Protocol
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5">
+              <Cpu className="w-3.5 h-3.5 text-muted-foreground" />
+              Device (Optional)
+            </Label>
+            <div className="flex items-center gap-2">
+              <SelectDropdown
+                options={[
+                  { value: "", label: "Personal Command" },
+                  ...devices.map((d) => ({
+                    value: d.id,
+                    label: d.name,
+                  })),
+                ]}
+                value={deviceId}
+                onChange={(value) => {
+                  onDeviceIdChange(value);
+                  if (value) {
+                    const device = devices.find((d) => d.id === value);
+                    const linkedProtocolIds =
+                      device?.protocols?.map((p) => p.protocolId) || [];
+                    if (protocolId && !linkedProtocolIds.includes(protocolId)) {
+                      onProtocolIdChange(device?.defaultProtocolId || "");
+                    }
+                  }
+                }}
+                placeholder="Select device..."
+              />
+              {deviceId && (
+                <Link
+                  to={`/devices/${deviceId}/edit`}
+                  className="shrink-0"
+                  title="Edit device"
+                >
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                </Link>
+              )}
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label className="flex items-center gap-1.5">
+              <Layers className="w-3.5 h-3.5 text-muted-foreground" />
+              Protocol
+            </Label>
+            <div className="flex items-center gap-2">
+              <SelectDropdown
+                options={[
+                  { value: "", label: "None" },
+                  ...availableProtocols.map((p) => ({
+                    value: p.id,
+                    label: `${p.name} (v${p.version})`,
+                  })),
+                ]}
+                value={protocolId}
+                onChange={onProtocolIdChange}
+                placeholder="Select protocol..."
+              />
+              {protocolId && (
+                <Link
+                  to={`/protocols/${protocolId}/edit`}
+                  className="shrink-0"
+                  title="Edit protocol"
+                >
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-9 w-9"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+        {deviceId && (
+          <p className="text-[10px] text-muted-foreground">
+            Commands linked to a device appear in that device&apos;s command
+            list.
+          </p>
+        )}
+      </div>
+
+      {/* Command Source Selection */}
+      <div className="p-4 bg-muted/20 rounded-lg border border-border/50 space-y-4">
+        <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground uppercase">
+          <FileCode className="w-3.5 h-3.5" />
+          Command Source
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              onSourceChange("CUSTOM");
+              onTemplateIdChange("");
+            }}
+            className={cn(
+              "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
+              source === "CUSTOM"
+                ? "bg-primary/5 border-primary shadow-sm"
+                : "bg-card border-border/50",
+            )}
+          >
+            <FileCode className="w-5 h-5 text-orange-500" />
+            <span className="font-semibold text-sm">Custom Command</span>
+            <span className="text-[10px] text-muted-foreground text-center">
+              Manually define payload
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={() => onSourceChange("PROTOCOL")}
+            className={cn(
+              "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
+              source === "PROTOCOL"
+                ? "bg-primary/5 border-primary shadow-sm"
+                : "bg-card border-border/50",
+            )}
+          >
+            <Layers className="w-5 h-5 text-blue-500" />
+            <span className="font-semibold text-sm">From Template</span>
+            <span className="text-[10px] text-muted-foreground text-center">
+              Use protocol template
+            </span>
+          </button>
+        </div>
+
+        {/* Template Picker - shown when PROTOCOL source is selected */}
+        {source === "PROTOCOL" && (
+          <div className="space-y-3 pt-2 border-t border-border/50">
+            {!protocolId ? (
+              <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg text-xs text-blue-600 dark:text-blue-400 flex items-start gap-2">
+                <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+                <span>
+                  Please select a protocol first to see available templates
+                </span>
+              </div>
+            ) : availableTemplates.length === 0 ? (
+              <div className="p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg text-xs text-yellow-600 dark:text-yellow-400 flex items-start gap-2">
+                <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+                <span>
+                  No command templates available for{" "}
+                  {protocols.find((p) => p.id === protocolId)?.name ??
+                    "unknown protocol"}
+                </span>
+              </div>
+            ) : (
+              <>
+                <div className="space-y-2">
+                  <Label className="text-xs">
+                    Command Template <span className="text-destructive">*</span>
+                  </Label>
+                  <SelectDropdown
+                    options={availableTemplates.map((tmpl) => ({
+                      value: tmpl.id,
+                      label: `${tmpl.name} - ${tmpl.description || ""}`,
+                    }))}
+                    value={templateId}
+                    onChange={(value) => {
+                      onTemplateIdChange(value);
+                      const template = availableTemplates.find(
+                        (tmpl) => tmpl.id === value,
+                      );
+                      if (template?.parameters) {
+                        const defaultValues: Record<string, unknown> = {};
+                        template.parameters.forEach((param) => {
+                          if (param.defaultValue !== undefined) {
+                            defaultValues[param.name] = param.defaultValue;
+                          }
+                        });
+                        onParameterValuesChange(defaultValues);
+                      }
+                    }}
+                    placeholder="Select a template..."
+                  />
+                </div>
+
+                {/* Template Preview */}
+                {selectedTemplate && (
+                  <div className="space-y-2">
+                    <Label className="text-xs text-muted-foreground">
+                      Template Payload
+                    </Label>
+                    <div className="p-3 bg-muted/30 rounded-lg border border-border/50">
+                      <code className="text-xs font-mono text-blue-600 dark:text-blue-400">
+                        {selectedTemplate.payload}
+                      </code>
+                    </div>
+                    {selectedTemplate.description && (
+                      <p className="text-[10px] text-muted-foreground">
+                        {selectedTemplate.description}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {/* Computed Payload Preview */}
+                {selectedTemplate &&
+                  Object.keys(parameterValues).length > 0 && (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Label className="text-xs text-muted-foreground">
+                          Computed Payload
+                        </Label>
+                        <Info className="w-3 h-3 text-muted-foreground" />
+                      </div>
+                      <div className="p-3 bg-green-500/10 rounded-lg border border-green-500/20">
+                        <code className="text-xs font-mono text-green-600 dark:text-green-400">
+                          {(() => {
+                            try {
+                              return substituteParameters(
+                                selectedTemplate.payload,
+                                parameterValues,
+                                selectedTemplate.parameters || [],
+                              );
+                            } catch {
+                              return "Error computing payload";
+                            }
+                          })()}
+                        </code>
+                      </div>
+                      <p className="text-[10px] text-muted-foreground">
+                        This is the final payload that will be sent with your
+                        current parameter values
+                      </p>
+                    </div>
+                  )}
+
+                {/* Dynamic Parameter Inputs */}
+                {selectedTemplate?.parameters &&
+                  selectedTemplate.parameters.length > 0 && (
+                    <TemplateParameterInputs
+                      parameters={selectedTemplate.parameters}
+                      parameterValues={parameterValues}
+                      onParameterValuesChange={onParameterValuesChange}
+                    />
+                  )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label>{t("cmd.name")}</Label>
+          <Input
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>{t("cmd.group")}</Label>
+          <Input
+            value={group}
+            onChange={(e) => onGroupChange(e.target.value)}
+            placeholder="Device Name"
+          />
+        </div>
+      </div>
+
+      {/* Format and Encoding - only for CUSTOM commands */}
+      {source === "CUSTOM" && (
+        <>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>{t("cmd.format")}</Label>
+              <SelectDropdown
+                options={
+                  [
+                    { value: "TEXT", label: "TEXT" },
+                    { value: "HEX", label: "HEX" },
+                  ] as DropdownOption<DataMode>[]
+                }
+                value={mode}
+                onChange={(value) => onModeChange(value)}
+              />
+            </div>
+            {mode === "TEXT" && (
+              <div className="space-y-2">
+                <Label>Encoding</Label>
+                <SelectDropdown
+                  options={
+                    [
+                      { value: "UTF-8", label: "UTF-8" },
+                      { value: "ASCII", label: "ASCII" },
+                    ] as DropdownOption<TextEncoding>[]
+                  }
+                  value={encoding}
+                  onChange={(value) => onEncodingChange(value)}
+                />
+              </div>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label>{t("cmd.payload")}</Label>
+            <Textarea
+              value={payload}
+              onChange={(e) => onPayloadChange(e.target.value)}
+              className="font-mono text-xs"
+            />
+          </div>
+        </>
+      )}
+    </CardContent>
+  );
+};
+
+// -- Sub-component for template parameter inputs --
+
+interface TemplateParameterInputsProps {
+  parameters: SimpleParameter[];
+  parameterValues: Record<string, unknown>;
+  onParameterValuesChange: React.Dispatch<
+    React.SetStateAction<Record<string, unknown>>
+  >;
+}
+
+const TemplateParameterInputs: React.FC<TemplateParameterInputsProps> = ({
+  parameters,
+  parameterValues,
+  onParameterValuesChange,
+}) => {
+  return (
+    <div className="space-y-3 pt-2 border-t border-border/50">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs font-semibold">Template Parameters</Label>
+        <Badge variant="outline" className="text-[10px]">
+          {parameters.length} parameter
+          {parameters.length !== 1 ? "s" : ""}
+        </Badge>
+      </div>
+
+      {parameters.map((param) => (
+        <div key={param.name} className="space-y-2">
+          <Label className="text-xs">
+            {param.label || param.name}
+            {param.required && <span className="text-destructive"> *</span>}
+          </Label>
+
+          {/* STRING input */}
+          {param.type === "STRING" && (
+            <div className="relative">
+              <Input
+                value={
+                  (parameterValues[param.name] as string) ??
+                  (param.defaultValue as string) ??
+                  ""
+                }
+                onChange={(e) =>
+                  onParameterValuesChange((prev) => ({
+                    ...prev,
+                    [param.name]: e.target.value,
+                  }))
+                }
+                placeholder={param.placeholder}
+                maxLength={param.maxLength}
+                className={cn(
+                  "h-8 text-xs font-mono pr-8",
+                  param.required &&
+                    !parameterValues[param.name] &&
+                    "border-destructive",
+                )}
+              />
+              {param.required && parameterValues[param.name] && (
+                <Check className="absolute right-2 top-2 w-4 h-4 text-green-500" />
+              )}
+            </div>
+          )}
+
+          {/* INTEGER input */}
+          {param.type === "INTEGER" && (
+            <div className="relative">
+              <Input
+                type="number"
+                value={
+                  (parameterValues[param.name] as number) ??
+                  (param.defaultValue as number) ??
+                  ""
+                }
+                onChange={(e) =>
+                  onParameterValuesChange((prev) => ({
+                    ...prev,
+                    [param.name]: parseInt(e.target.value),
+                  }))
+                }
+                min={param.min}
+                max={param.max}
+                className={cn(
+                  "h-8 text-xs font-mono pr-8",
+                  param.required &&
+                    parameterValues[param.name] === undefined &&
+                    "border-destructive",
+                )}
+              />
+              {param.required && parameterValues[param.name] !== undefined && (
+                <Check className="absolute right-2 top-2 w-4 h-4 text-green-500" />
+              )}
+            </div>
+          )}
+
+          {/* FLOAT input */}
+          {param.type === "FLOAT" && (
+            <div className="relative">
+              <Input
+                type="number"
+                step="any"
+                value={
+                  (parameterValues[param.name] as number) ??
+                  (param.defaultValue as number) ??
+                  ""
+                }
+                onChange={(e) =>
+                  onParameterValuesChange((prev) => ({
+                    ...prev,
+                    [param.name]: parseFloat(e.target.value),
+                  }))
+                }
+                min={param.min}
+                max={param.max}
+                className={cn(
+                  "h-8 text-xs font-mono pr-8",
+                  param.required &&
+                    parameterValues[param.name] === undefined &&
+                    "border-destructive",
+                )}
+              />
+              {param.required && parameterValues[param.name] !== undefined && (
+                <Check className="absolute right-2 top-2 w-4 h-4 text-green-500" />
+              )}
+            </div>
+          )}
+
+          {/* ENUM dropdown */}
+          {param.type === "ENUM" && param.options && (
+            <SelectDropdown
+              options={param.options.map((opt) => ({
+                label: opt.label || String(opt.value),
+                value: opt.value || "",
+              }))}
+              value={
+                (parameterValues[param.name] as string) ??
+                param.defaultValue ??
+                ""
+              }
+              onChange={(value) =>
+                onParameterValuesChange((prev) => ({
+                  ...prev,
+                  [param.name]: value,
+                }))
+              }
+            />
+          )}
+
+          {/* BOOLEAN checkbox */}
+          {param.type === "BOOLEAN" && (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                checked={
+                  (parameterValues[param.name] as boolean) ??
+                  (param.defaultValue as boolean) ??
+                  false
+                }
+                onChange={(e) =>
+                  onParameterValuesChange((prev) => ({
+                    ...prev,
+                    [param.name]: e.target.checked,
+                  }))
+                }
+              />
+              <span className="text-xs text-muted-foreground">
+                {param.description}
+              </span>
+            </div>
+          )}
+
+          {/* Enhanced Parameter Help */}
+          {param.type !== "BOOLEAN" && (
+            <div className="space-y-1">
+              {param.description && (
+                <p className="text-[10px] text-muted-foreground">
+                  {param.description}
+                </p>
+              )}
+              <div className="flex flex-wrap gap-2 text-[9px] text-muted-foreground">
+                {param.defaultValue !== undefined && (
+                  <span className="inline-flex items-center gap-1">
+                    <span className="font-semibold">Default:</span>
+                    <code className="px-1 py-0.5 bg-muted rounded">
+                      {String(param.defaultValue)}
+                    </code>
+                  </span>
+                )}
+                {param.type === "INTEGER" &&
+                  (param.min !== undefined || param.max !== undefined) && (
+                    <span className="inline-flex items-center gap-1">
+                      <span className="font-semibold">Range:</span>
+                      <code className="px-1 py-0.5 bg-muted rounded">
+                        {param.min ?? "-\u221E"} to {param.max ?? "\u221E"}
+                      </code>
+                    </span>
+                  )}
+                {param.type === "FLOAT" &&
+                  (param.min !== undefined || param.max !== undefined) && (
+                    <span className="inline-flex items-center gap-1">
+                      <span className="font-semibold">Range:</span>
+                      <code className="px-1 py-0.5 bg-muted rounded">
+                        {param.min ?? "-\u221E"} to {param.max ?? "\u221E"}
+                      </code>
+                    </span>
+                  )}
+                {param.type === "STRING" && param.maxLength && (
+                  <span className="inline-flex items-center gap-1">
+                    <span className="font-semibold">Max length:</span>
+                    <code className="px-1 py-0.5 bg-muted rounded">
+                      {param.maxLength}
+                    </code>
+                  </span>
+                )}
+                {param.required && (
+                  <Badge
+                    variant="destructive"
+                    className="text-[8px] h-4 px-1.5"
+                  >
+                    Required
+                  </Badge>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BasicTab;

--- a/src/components/CommandForm/ContextTab.tsx
+++ b/src/components/CommandForm/ContextTab.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { Textarea } from "../ui/Textarea";
+import { Label } from "../ui/Label";
+import { CardContent } from "../ui/Card";
+import { Checkbox } from "../ui/Checkbox";
+import { generateId } from "../../lib/utils";
+import type { ProjectContext } from "../../types";
+
+interface ContextTabProps {
+  contexts: ProjectContext[];
+  contextIds: string[];
+  onContextIdsChange: (ids: string[]) => void;
+  contextTitle: string;
+  onContextTitleChange: (title: string) => void;
+  contextContent: string;
+  onContextContentChange: (content: string) => void;
+  onUpdateContext?: (context: ProjectContext) => void;
+  onCreateContext: (context: ProjectContext) => void;
+}
+
+const ContextTab: React.FC<ContextTabProps> = ({
+  contexts,
+  contextIds,
+  onContextIdsChange,
+  contextTitle,
+  onContextTitleChange,
+  contextContent,
+  onContextContentChange,
+  onUpdateContext,
+  onCreateContext,
+}) => {
+  const activeContexts = contexts.filter((c) => contextIds.includes(c.id));
+
+  const handleSaveContext = () => {
+    if (contextTitle && contextContent) {
+      if (contextIds.length === 1 && activeContexts.length === 1) {
+        if (onUpdateContext)
+          onUpdateContext({
+            ...activeContexts[0],
+            title: contextTitle,
+            content: contextContent,
+          });
+      } else {
+        const newCtx: ProjectContext = {
+          id: generateId(),
+          title: contextTitle,
+          content: contextContent,
+          source: "USER" as const,
+          createdAt: Date.now(),
+        };
+        onCreateContext(newCtx);
+        onContextIdsChange([...contextIds, newCtx.id]);
+      }
+    }
+  };
+
+  return (
+    <CardContent className="pt-6 space-y-4 h-full flex flex-col">
+      <div className="flex items-end gap-2">
+        <div className="space-y-1 flex-1">
+          <Label>Context ID / Link</Label>
+          <div className="space-y-2">
+            {contexts.map((context) => (
+              <Checkbox
+                key={context.id}
+                checked={contextIds.includes(context.id)}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    onContextIdsChange([...contextIds, context.id]);
+                  } else {
+                    onContextIdsChange(
+                      contextIds.filter((id) => id !== context.id),
+                    );
+                  }
+                }}
+                label={context.title}
+              />
+            ))}
+          </div>
+        </div>
+        <Button type="button" variant="secondary" onClick={handleSaveContext}>
+          Save Context
+        </Button>
+      </div>
+
+      <div className="space-y-1">
+        <Label>Context Title</Label>
+        <Input
+          value={contextTitle}
+          onChange={(e) => onContextTitleChange(e.target.value)}
+          placeholder="Protocol Manual Section 1..."
+        />
+      </div>
+
+      <div className="space-y-1 flex-1 flex flex-col">
+        <Label>Content (Markdown/Text)</Label>
+        <Textarea
+          value={contextContent}
+          onChange={(e) => onContextContentChange(e.target.value)}
+          className="flex-1 resize-none font-mono text-xs"
+          placeholder="Paste documentation or protocol details here..."
+        />
+      </div>
+    </CardContent>
+  );
+};
+
+export default ContextTab;

--- a/src/components/CommandForm/FramingTab.tsx
+++ b/src/components/CommandForm/FramingTab.tsx
@@ -1,0 +1,217 @@
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+import { Input } from "../ui/Input";
+import { Label } from "../ui/Label";
+import { SelectDropdown } from "../ui/Select";
+import { CardContent } from "../ui/Card";
+import { Checkbox } from "../ui/Checkbox";
+import CodeEditor from "../ui/CodeEditor";
+import type { DropdownOption } from "../ui/Dropdown";
+import type { FramingStrategy, FramingConfig } from "../../types";
+
+interface FramingTabProps {
+  framingEnabled: boolean;
+  onFramingEnabledChange: (enabled: boolean) => void;
+  framingConfig: FramingConfig;
+  onFramingConfigChange: (config: FramingConfig) => void;
+  framingPersistence: "TRANSIENT" | "PERSISTENT";
+  onFramingPersistenceChange: (value: "TRANSIENT" | "PERSISTENT") => void;
+}
+
+const DEFAULT_FRAMER_SCRIPT = `// Custom Framer Script
+// Args: chunks (Array<{data: Uint8Array, timestamp: number}>), forceFlush (boolean)
+// Return: { frames: [], remaining: [] }
+
+// Example: Merge everything into one frame on timeout/flush
+if (forceFlush) {
+    const totalLen = chunks.reduce((acc, c) => acc + c.data.length, 0);
+    const merged = new Uint8Array(totalLen);
+    let offset = 0;
+    for(const c of chunks) {
+        merged.set(c.data, offset);
+        offset += c.data.length;
+    }
+    // Return single combined frame
+    return {
+        frames: [{ data: merged, timestamp: Date.now() }],
+        remaining: []
+    };
+}
+
+// Keep accumulating if not flushed
+return { frames: [], remaining: chunks };`;
+
+const FramingTab: React.FC<FramingTabProps> = ({
+  framingEnabled,
+  onFramingEnabledChange,
+  framingConfig,
+  onFramingConfigChange,
+  framingPersistence,
+  onFramingPersistenceChange,
+}) => {
+  return (
+    <CardContent className="pt-6 space-y-6">
+      <div className="p-3 bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800 rounded-md flex gap-2">
+        <AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-500 shrink-0 mt-0.5" />
+        <div className="text-xs text-amber-800 dark:text-amber-300">
+          <strong>Note:</strong> Framing overrides allow this specific command
+          to parse incoming data differently (e.g., waiting for a specific
+          delimiter).
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Checkbox
+          checked={framingEnabled}
+          onChange={(e) => onFramingEnabledChange(e.target.checked)}
+          label="Override Global Framing"
+          labelClassName="font-bold"
+        />
+        {framingEnabled && (
+          <SelectDropdown
+            options={
+              [
+                { value: "TRANSIENT", label: "Transient (One-Shot)" },
+                {
+                  value: "PERSISTENT",
+                  label: "Persistent (Change Global)",
+                },
+              ] as DropdownOption<"TRANSIENT" | "PERSISTENT">[]
+            }
+            value={framingPersistence}
+            onChange={(value) => onFramingPersistenceChange(value)}
+            size="sm"
+            className="w-45"
+          />
+        )}
+      </div>
+
+      {framingEnabled && (
+        <div className="pl-6 space-y-4 animate-in slide-in-from-top-2 border-l-2 border-border ml-2">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label className="text-xs">Strategy</Label>
+              <SelectDropdown
+                options={
+                  [
+                    { value: "NONE", label: "None (Raw Stream)" },
+                    { value: "DELIMITER", label: "Delimiter" },
+                    { value: "TIMEOUT", label: "Timeout" },
+                    {
+                      value: "PREFIX_LENGTH",
+                      label: "Prefix Length",
+                    },
+                    { value: "SCRIPT", label: "Custom Script" },
+                  ] as DropdownOption<FramingStrategy>[]
+                }
+                value={framingConfig.strategy}
+                onChange={(newStrategy) => {
+                  let newScript = framingConfig.script;
+
+                  if (
+                    newStrategy === "SCRIPT" &&
+                    (!newScript || newScript.trim() === "")
+                  ) {
+                    newScript = DEFAULT_FRAMER_SCRIPT;
+                  }
+
+                  onFramingConfigChange({
+                    ...framingConfig,
+                    strategy: newStrategy,
+                    script: newScript,
+                  });
+                }}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Timeout (ms)</Label>
+              <Input
+                type="number"
+                value={framingConfig.timeout}
+                onChange={(e) =>
+                  onFramingConfigChange({
+                    ...framingConfig,
+                    timeout: parseInt(e.target.value),
+                  })
+                }
+                className="h-9 text-sm"
+              />
+            </div>
+          </div>
+
+          {framingConfig.strategy === "DELIMITER" && (
+            <div className="space-y-1">
+              <Label className="text-xs">Delimiter (Hex/Text)</Label>
+              <Input
+                value={framingConfig.delimiter}
+                onChange={(e) =>
+                  onFramingConfigChange({
+                    ...framingConfig,
+                    delimiter: e.target.value,
+                  })
+                }
+                placeholder="e.g. \n or 0D 0A"
+                className="h-9 text-sm font-mono"
+              />
+            </div>
+          )}
+
+          {framingConfig.strategy === "PREFIX_LENGTH" && (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label className="text-xs">Header Size (Bytes)</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  max={8}
+                  value={framingConfig.prefixLengthSize}
+                  onChange={(e) =>
+                    onFramingConfigChange({
+                      ...framingConfig,
+                      prefixLengthSize: parseInt(e.target.value),
+                    })
+                  }
+                  className="h-9 text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs">Byte Order</Label>
+                <SelectDropdown
+                  options={
+                    [
+                      { value: "LE", label: "Little Endian" },
+                      { value: "BE", label: "Big Endian" },
+                    ] as DropdownOption<"LE" | "BE">[]
+                  }
+                  value={framingConfig.byteOrder}
+                  onChange={(value) =>
+                    onFramingConfigChange({
+                      ...framingConfig,
+                      byteOrder: value,
+                    })
+                  }
+                />
+              </div>
+            </div>
+          )}
+
+          {framingConfig.strategy === "SCRIPT" && (
+            <div className="space-y-1">
+              <Label className="text-xs">Framer Script</Label>
+              <CodeEditor
+                value={framingConfig.script || ""}
+                onChange={(val) =>
+                  onFramingConfigChange({ ...framingConfig, script: val })
+                }
+                height="150px"
+                className="border-l-4 border-l-purple-500/30"
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </CardContent>
+  );
+};
+
+export default FramingTab;

--- a/src/components/CommandForm/ParametersTab.tsx
+++ b/src/components/CommandForm/ParametersTab.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Plus, Trash2 } from "lucide-react";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { Label } from "../ui/Label";
+import { SelectDropdown } from "../ui/Select";
+import { CardContent } from "../ui/Card";
+import type { DropdownOption } from "../ui/Dropdown";
+import type { CommandParameter, ParameterType } from "../../types";
+
+interface ParametersTabProps {
+  parameters: CommandParameter[];
+  onAdd: () => void;
+  onUpdate: (idx: number, updates: Partial<CommandParameter>) => void;
+  onRemove: (idx: number) => void;
+}
+
+const ParametersTab: React.FC<ParametersTabProps> = ({
+  parameters,
+  onAdd,
+  onUpdate,
+  onRemove,
+}) => {
+  return (
+    <CardContent className="pt-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <div className="text-sm text-muted-foreground">
+          Define variables to be used in scripting.
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          onClick={onAdd}
+          variant="outline"
+          className="h-8 gap-1"
+        >
+          <Plus className="w-3.5 h-3.5" /> Add Parameter
+        </Button>
+      </div>
+
+      <div className="space-y-3">
+        {parameters.length === 0 && (
+          <div className="text-center py-10 text-muted-foreground italic bg-muted/20 rounded-lg">
+            No parameters defined.
+          </div>
+        )}
+        {parameters.map((param, idx) => (
+          <div
+            key={param.id}
+            className="p-3 border rounded-lg bg-card grid grid-cols-12 gap-3 items-end animate-in fade-in slide-in-from-bottom-2"
+          >
+            <div className="col-span-3 space-y-1">
+              <Label className="text-[10px]">Var Name</Label>
+              <Input
+                value={param.name}
+                onChange={(e) => onUpdate(idx, { name: e.target.value })}
+                className="h-8 text-xs font-mono"
+                placeholder="varName"
+              />
+            </div>
+            <div className="col-span-3 space-y-1">
+              <Label className="text-[10px]">Label</Label>
+              <Input
+                value={param.label || ""}
+                onChange={(e) => onUpdate(idx, { label: e.target.value })}
+                className="h-8 text-xs"
+                placeholder="Display Label"
+              />
+            </div>
+            <div className="col-span-2 space-y-1">
+              <Label className="text-[10px]">Type</Label>
+              <SelectDropdown
+                options={
+                  [
+                    { value: "STRING", label: "String" },
+                    { value: "INTEGER", label: "Integer" },
+                    { value: "FLOAT", label: "Float" },
+                    { value: "BOOLEAN", label: "Boolean" },
+                  ] as DropdownOption<ParameterType>[]
+                }
+                value={param.type}
+                onChange={(value) => onUpdate(idx, { type: value })}
+                size="sm"
+              />
+            </div>
+            <div className="col-span-3 space-y-1">
+              <Label className="text-[10px]">Default</Label>
+              <Input
+                value={String(param.defaultValue ?? "")}
+                onChange={(e) =>
+                  onUpdate(idx, { defaultValue: e.target.value })
+                }
+                className="h-8 text-xs"
+                placeholder="Optional"
+              />
+            </div>
+            <div className="col-span-1">
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                onClick={() => onRemove(idx)}
+                className="h-8 w-8 text-destructive hover:bg-destructive/10"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </CardContent>
+  );
+};
+
+export default ParametersTab;

--- a/src/components/CommandForm/ProcessingTab.tsx
+++ b/src/components/CommandForm/ProcessingTab.tsx
@@ -1,0 +1,192 @@
+import React from "react";
+import { Search, FileCode } from "lucide-react";
+import { Input } from "../ui/Input";
+import { Label } from "../ui/Label";
+import { SelectDropdown } from "../ui/Select";
+import { CardContent } from "../ui/Card";
+import { Checkbox } from "../ui/Checkbox";
+import CodeEditor from "../ui/CodeEditor";
+import { cn } from "../../lib/utils";
+import type { DropdownOption } from "../ui/Dropdown";
+import type { MatchType } from "../../types";
+
+interface ProcessingTabProps {
+  preRequestEnabled: boolean;
+  onPreRequestEnabledChange: (enabled: boolean) => void;
+  preRequestScript: string;
+  onPreRequestScriptChange: (script: string) => void;
+  postResponseEnabled: boolean;
+  onPostResponseEnabledChange: (enabled: boolean) => void;
+  responseMode: "PATTERN" | "SCRIPT";
+  onResponseModeChange: (mode: "PATTERN" | "SCRIPT") => void;
+  matchType: MatchType;
+  onMatchTypeChange: (type: MatchType) => void;
+  pattern: string;
+  onPatternChange: (pattern: string) => void;
+  timeout: number;
+  onTimeoutChange: (timeout: number) => void;
+  postResponseScript: string;
+  onPostResponseScriptChange: (script: string) => void;
+}
+
+const ProcessingTab: React.FC<ProcessingTabProps> = ({
+  preRequestEnabled,
+  onPreRequestEnabledChange,
+  preRequestScript,
+  onPreRequestScriptChange,
+  postResponseEnabled,
+  onPostResponseEnabledChange,
+  responseMode,
+  onResponseModeChange,
+  matchType,
+  onMatchTypeChange,
+  pattern,
+  onPatternChange,
+  timeout,
+  onTimeoutChange,
+  postResponseScript,
+  onPostResponseScriptChange,
+}) => {
+  return (
+    <CardContent className="pt-6 space-y-8 h-full flex flex-col">
+      <div className="space-y-3">
+        <Checkbox
+          checked={preRequestEnabled}
+          onChange={(e) => onPreRequestEnabledChange(e.target.checked)}
+          label="Enable Pre-Request Handling"
+          labelClassName="font-bold text-sm"
+        />
+        {preRequestEnabled && (
+          <div className="pl-6 space-y-2 animate-in slide-in-from-top-1">
+            <CodeEditor
+              value={preRequestScript}
+              onChange={onPreRequestScriptChange}
+              height="120px"
+              className="border-l-4 border-l-blue-500/30"
+            />
+            <p className="text-[10px] text-muted-foreground italic">
+              Modify payload before transmission. Variables available:{" "}
+              <code>payload</code>, <code>params</code>.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        <Checkbox
+          checked={postResponseEnabled}
+          onChange={(e) => onPostResponseEnabledChange(e.target.checked)}
+          label="Enable Post-Response Handling"
+          labelClassName="font-bold text-sm"
+        />
+
+        {postResponseEnabled && (
+          <div className="pl-6 space-y-4 animate-in slide-in-from-top-1">
+            <div className="grid grid-cols-2 gap-3">
+              <div
+                onClick={() => onResponseModeChange("PATTERN")}
+                className={cn(
+                  "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
+                  responseMode === "PATTERN"
+                    ? "bg-primary/5 border-primary shadow-sm ring-1 ring-primary/20"
+                    : "bg-card",
+                )}
+              >
+                <Search
+                  className={cn(
+                    "w-5 h-5",
+                    responseMode === "PATTERN"
+                      ? "text-primary"
+                      : "text-muted-foreground",
+                  )}
+                />
+                <div className="text-center">
+                  <div className="font-bold text-xs">Simple Pattern</div>
+                  <div className="text-[9px] text-muted-foreground mt-0.5">
+                    Success on string match
+                  </div>
+                </div>
+              </div>
+              <div
+                onClick={() => onResponseModeChange("SCRIPT")}
+                className={cn(
+                  "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
+                  responseMode === "SCRIPT"
+                    ? "bg-primary/5 border-primary shadow-sm ring-1 ring-primary/20"
+                    : "bg-card",
+                )}
+              >
+                <FileCode
+                  className={cn(
+                    "w-5 h-5",
+                    responseMode === "SCRIPT"
+                      ? "text-primary"
+                      : "text-muted-foreground",
+                  )}
+                />
+                <div className="text-center">
+                  <div className="font-bold text-xs">Advanced Script</div>
+                  <div className="text-[9px] text-muted-foreground mt-0.5">
+                    JS logic & extraction
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {responseMode === "PATTERN" ? (
+              <div className="p-4 bg-muted/20 border border-border rounded-lg grid grid-cols-3 gap-4 animate-in fade-in">
+                <div className="space-y-1">
+                  <Label className="text-[10px]">Type</Label>
+                  <SelectDropdown
+                    options={
+                      [
+                        { value: "CONTAINS", label: "Contains" },
+                        { value: "REGEX", label: "Regex" },
+                      ] as DropdownOption<MatchType>[]
+                    }
+                    value={matchType}
+                    onChange={(value) => onMatchTypeChange(value)}
+                    size="sm"
+                  />
+                </div>
+                <div className="col-span-2 space-y-1">
+                  <Label className="text-[10px]">Pattern</Label>
+                  <Input
+                    className="h-8 text-xs font-mono"
+                    value={pattern}
+                    onChange={(e) => onPatternChange(e.target.value)}
+                    placeholder="OK"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-[10px]">Timeout (ms)</Label>
+                  <Input
+                    type="number"
+                    className="h-8 text-xs"
+                    value={timeout}
+                    onChange={(e) => onTimeoutChange(parseInt(e.target.value))}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2 animate-in fade-in">
+                <CodeEditor
+                  value={postResponseScript}
+                  onChange={onPostResponseScriptChange}
+                  height="150px"
+                  className="border-l-4 border-l-emerald-500/30"
+                />
+                <p className="text-[10px] text-muted-foreground italic">
+                  Validate and extract data. Variables: <code>data</code>,{" "}
+                  <code>raw</code>, <code>setVar</code>, <code>log</code>.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </CardContent>
+  );
+};
+
+export default ProcessingTab;

--- a/src/components/CommandForm/ProtocolTab.tsx
+++ b/src/components/CommandForm/ProtocolTab.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { Calculator, Terminal } from "lucide-react";
+import { Button } from "../ui/Button";
+import { Input } from "../ui/Input";
+import { Label } from "../ui/Label";
+import { SelectDropdown } from "../ui/Select";
+import { CardContent } from "../ui/Card";
+import { cn } from "../../lib/utils";
+import type { DropdownOption } from "../ui/Dropdown";
+import {
+  generateModbusFrame,
+  MODBUS_FUNCTIONS,
+  AT_COMMAND_LIBRARY,
+  type ModbusParams,
+} from "../../services/protocolUtils";
+import type { DataMode } from "../../types";
+
+interface ProtocolTabProps {
+  protoType: "MODBUS" | "AT";
+  onProtoTypeChange: (type: "MODBUS" | "AT") => void;
+  mbParams: ModbusParams;
+  onMbParamsChange: (params: ModbusParams) => void;
+  onUsePayload: (mode: DataMode, payload: string, description?: string) => void;
+}
+
+const ProtocolTab: React.FC<ProtocolTabProps> = ({
+  protoType,
+  onProtoTypeChange,
+  mbParams,
+  onMbParamsChange,
+  onUsePayload,
+}) => {
+  return (
+    <CardContent className="pt-6 space-y-6">
+      <div className="grid grid-cols-2 gap-4">
+        <div
+          onClick={() => onProtoTypeChange("MODBUS")}
+          className={cn(
+            "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
+            protoType === "MODBUS"
+              ? "bg-primary/5 border-primary shadow-sm"
+              : "bg-card",
+          )}
+        >
+          <Calculator className="w-6 h-6 text-blue-500" />
+          <span className="font-bold text-sm">Modbus RTU Generator</span>
+        </div>
+        <div
+          onClick={() => onProtoTypeChange("AT")}
+          className={cn(
+            "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
+            protoType === "AT"
+              ? "bg-primary/5 border-primary shadow-sm"
+              : "bg-card",
+          )}
+        >
+          <Terminal className="w-6 h-6 text-emerald-500" />
+          <span className="font-bold text-sm">AT Command Library</span>
+        </div>
+      </div>
+
+      {protoType === "MODBUS" && (
+        <div className="space-y-4 p-4 border rounded-lg bg-muted/10 animate-in fade-in">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <Label className="text-xs">Slave ID</Label>
+              <Input
+                type="number"
+                value={mbParams.slaveId}
+                onChange={(e) =>
+                  onMbParamsChange({
+                    ...mbParams,
+                    slaveId: parseInt(e.target.value),
+                  })
+                }
+                className="h-8"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Function</Label>
+              <SelectDropdown
+                options={MODBUS_FUNCTIONS.map(
+                  (f): DropdownOption<number> => ({
+                    value: f.code,
+                    label: f.name,
+                  }),
+                )}
+                value={mbParams.functionCode}
+                onChange={(value) =>
+                  onMbParamsChange({
+                    ...mbParams,
+                    functionCode: value,
+                  })
+                }
+                size="sm"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Start Address</Label>
+              <Input
+                type="number"
+                value={mbParams.startAddress}
+                onChange={(e) =>
+                  onMbParamsChange({
+                    ...mbParams,
+                    startAddress: parseInt(e.target.value),
+                  })
+                }
+                className="h-8"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Quantity/Value</Label>
+              <Input
+                type="number"
+                value={mbParams.quantityOrValue}
+                onChange={(e) =>
+                  onMbParamsChange({
+                    ...mbParams,
+                    quantityOrValue: parseInt(e.target.value),
+                  })
+                }
+                className="h-8"
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <code className="flex-1 bg-background border p-2 rounded text-xs font-mono">
+              {generateModbusFrame(mbParams)}
+            </code>
+            <Button
+              size="sm"
+              type="button"
+              onClick={() => onUsePayload("HEX", generateModbusFrame(mbParams))}
+            >
+              Use Payload
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {protoType === "AT" && (
+        <div className="space-y-4 p-4 border rounded-lg bg-muted/10 animate-in fade-in">
+          <div className="space-y-2">
+            <Label>Common AT Commands</Label>
+            <div className="h-50 overflow-y-auto border rounded bg-background p-2 space-y-1">
+              {Object.entries(AT_COMMAND_LIBRARY).map(([cat, cmds]) => (
+                <div key={cat} className="mb-2">
+                  <div className="text-[10px] font-bold text-muted-foreground uppercase mb-1 sticky top-0 bg-background">
+                    {cat}
+                  </div>
+                  {cmds.map((c) => (
+                    <div
+                      key={c.cmd}
+                      className="flex justify-between items-center p-1.5 hover:bg-muted rounded cursor-pointer group"
+                      onClick={() => onUsePayload("TEXT", c.cmd, c.desc)}
+                    >
+                      <code className="text-xs font-bold text-primary">
+                        {c.cmd}
+                      </code>
+                      <span className="text-[10px] text-muted-foreground">
+                        {c.desc}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </CardContent>
+  );
+};
+
+export default ProtocolTab;

--- a/src/components/CommandFormModal.tsx
+++ b/src/components/CommandFormModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { Link } from "react-router-dom";
 import {
   SavedCommand,
   DataMode,
@@ -9,52 +8,23 @@ import {
   SerialSequence,
   ProjectContext,
   CommandParameter,
-  ParameterType,
-  FramingStrategy,
   FramingConfig,
 } from "../types";
 import { useStore } from "../lib/store";
-import {
-  X,
-  Check,
-  AlertTriangle,
-  Calculator,
-  Plus,
-  Trash2,
-  FileCode,
-  Search,
-  Terminal,
-  Cpu,
-  Layers,
-  ExternalLink,
-  Info,
-} from "lucide-react";
-import { substituteParameters } from "../lib/commandBuilder";
+import { X, Check, Layers } from "lucide-react";
 import { Button } from "./ui/Button";
-import { Input } from "./ui/Input";
-import { Textarea } from "./ui/Textarea";
-import { SelectDropdown } from "./ui/Select";
-import { DropdownOption } from "./ui/Dropdown";
-import { Label } from "./ui/Label";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent,
-  CardFooter,
-} from "./ui/Card";
+import { Card, CardHeader, CardTitle, CardFooter } from "./ui/Card";
 import { Badge } from "./ui/Badge";
 import { TabBar, type TabItem } from "./ui/TabBar";
 import { cn, generateId } from "../lib/utils";
-import {
-  generateModbusFrame,
-  MODBUS_FUNCTIONS,
-  AT_COMMAND_LIBRARY,
-  ModbusParams,
-} from "../services/protocolUtils";
+import type { ModbusParams } from "../services/protocolUtils";
 import { useTranslation } from "react-i18next";
-import CodeEditor from "./ui/CodeEditor";
-import { Checkbox } from "./ui/Checkbox";
+import BasicTab from "./CommandForm/BasicTab";
+import ParametersTab from "./CommandForm/ParametersTab";
+import ProcessingTab from "./CommandForm/ProcessingTab";
+import FramingTab from "./CommandForm/FramingTab";
+import ContextTab from "./CommandForm/ContextTab";
+import ProtocolTab from "./CommandForm/ProtocolTab";
 
 interface Props {
   initialData?: Partial<SavedCommand>;
@@ -108,13 +78,14 @@ const CommandFormModal: React.FC<Props> = ({
   const [templateId, setTemplateId] = useState<string>(
     initialData?.protocolLayer?.protocolCommandId || "",
   );
-  const [parameterValues, setParameterValues] = useState<Record<string, any>>(
-    // Initialize from commandLayer.parameterEnhancements if editing PROTOCOL command
+  const [parameterValues, setParameterValues] = useState<
+    Record<string, unknown>
+  >(
     initialData?.commandLayer?.parameterEnhancements
       ? Object.entries(initialData.commandLayer.parameterEnhancements).reduce(
-          (acc, [name, enhancement]) => ({
+          (acc, [paramName, enhancement]) => ({
             ...acc,
-            [name]: enhancement.customDefault,
+            [paramName]: enhancement.customDefault,
           }),
           {},
         )
@@ -123,22 +94,14 @@ const CommandFormModal: React.FC<Props> = ({
 
   // Get protocols available for the selected device
   const availableProtocols = useMemo(() => {
-    if (!deviceId) {
-      // No device selected, show all protocols
-      return protocols;
-    }
+    if (!deviceId) return protocols;
     const device = devices.find((d) => d.id === deviceId);
-    if (!device || !device.protocols?.length) {
-      // Device has no protocols, show all
-      return protocols;
-    }
-    // Filter protocols to only those linked to device
+    if (!device || !device.protocols?.length) return protocols;
     const linkedProtocolIds = device.protocols.map((p) => p.protocolId);
     return protocols.filter((p) => linkedProtocolIds.includes(p.id));
   }, [deviceId, devices, protocols]);
 
   // Get templates available for the selected protocol
-  // Filter to only SIMPLE type templates (Phase 2 focuses on simple commands)
   const availableTemplates = useMemo(() => {
     if (!protocolId) return [];
     const protocol = protocols.find((p) => p.id === protocolId);
@@ -148,12 +111,12 @@ const CommandFormModal: React.FC<Props> = ({
       );
       return [];
     }
-    const allTemplates = protocol.commands;
-    // Only show SIMPLE templates for now
-    return allTemplates.filter((t) => t.type === "SIMPLE");
+    return protocol.commands.filter((tmpl) => tmpl.type === "SIMPLE");
   }, [protocolId, protocols]);
 
-  const selectedTemplate = availableTemplates.find((t) => t.id === templateId);
+  const selectedTemplate = availableTemplates.find(
+    (tmpl) => tmpl.id === templateId,
+  );
 
   const [contextIds, setContextIds] = useState<string[]>(
     initialData?.contextIds || [],
@@ -227,6 +190,8 @@ const CommandFormModal: React.FC<Props> = ({
     quantityOrValue: 1,
   });
 
+  // ---- Handlers ----
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (activeContexts.length === 1 && onUpdateContext)
@@ -236,14 +201,11 @@ const CommandFormModal: React.FC<Props> = ({
         title: contextTitle,
       });
 
-    // Capture timestamp once at start of handler
-    // eslint-disable-next-line react-hooks/purity -- Date.now() is fine in event handlers
     const now = Date.now();
 
     let commandData: Omit<SavedCommand, "id">;
 
     if (source === "PROTOCOL") {
-      // Validate: protocol and template must be selected
       if (!protocolId || !templateId) {
         alert("Please select both a protocol and a command template");
         return;
@@ -254,7 +216,6 @@ const CommandFormModal: React.FC<Props> = ({
         return;
       }
 
-      // Validate required parameters
       const missingParams = selectedTemplate.parameters?.filter(
         (p) => p.required && !parameterValues[p.name],
       );
@@ -265,47 +226,38 @@ const CommandFormModal: React.FC<Props> = ({
         return;
       }
 
-      // Build PROTOCOL command with protocolLayer + commandLayer
       commandData = {
         name,
         description,
         group: group.trim() || undefined,
         deviceId: deviceId || undefined,
         source: "PROTOCOL",
-
-        // Protocol Layer (L1) - from template
         protocolLayer: {
           protocolId,
           protocolCommandId: templateId,
           protocolVersion: "1.0",
           protocolCommandUpdatedAt: now,
-
-          // Copy from template
           payload: selectedTemplate.payload,
           mode: selectedTemplate.mode,
           encoding: selectedTemplate.encoding,
           parameters: selectedTemplate.parameters,
           validation: selectedTemplate.validation,
         },
-
-        // Command Layer (L2) - user customizations
         commandLayer: {
           group: group.trim() || undefined,
           parameterEnhancements: Object.entries(parameterValues).reduce(
-            (acc, [name, value]) => ({
+            (acc, [paramName, value]) => ({
               ...acc,
-              [name]: { customDefault: value },
+              [paramName]: { customDefault: value },
             }),
             {},
           ),
         },
-
         createdAt: initialData?.createdAt || now,
         updatedAt: now,
         contextIds,
       };
     } else {
-      // CUSTOM source - existing logic
       commandData = {
         name,
         description,
@@ -345,11 +297,6 @@ const CommandFormModal: React.FC<Props> = ({
     }
 
     onSave(commandData);
-
-    // If a device is selected and this is a new command, add it to the device's commandIds
-    // Note: The parent component will need to handle this coordination since onSave returns the new command ID
-    // This is typically handled by the caller after onSave completes
-
     onClose();
   };
 
@@ -377,6 +324,19 @@ const CommandFormModal: React.FC<Props> = ({
     newParams.splice(idx, 1);
     setParameters(newParams);
   };
+
+  const handleUsePayload = (
+    newMode: DataMode,
+    newPayload: string,
+    newDescription?: string,
+  ) => {
+    setMode(newMode);
+    setPayload(newPayload);
+    if (newDescription) setDescription(newDescription);
+    setActiveTab("basic");
+  };
+
+  // ---- Render ----
 
   return createPortal(
     <div
@@ -450,1252 +410,99 @@ const CommandFormModal: React.FC<Props> = ({
         >
           <div className="flex-1 flex flex-col min-h-0 overflow-y-auto">
             {activeTab === "basic" && (
-              <CardContent className="pt-6 space-y-4">
-                {/* Device & Protocol Selection */}
-                <div className="p-4 bg-muted/20 rounded-lg border border-border/50 space-y-4">
-                  <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground uppercase">
-                    <Layers className="w-3.5 h-3.5" />
-                    Device & Protocol
-                  </div>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <Label className="flex items-center gap-1.5">
-                        <Cpu className="w-3.5 h-3.5 text-muted-foreground" />
-                        Device (Optional)
-                      </Label>
-                      <div className="flex items-center gap-2">
-                        <SelectDropdown
-                          options={[
-                            { value: "", label: "Personal Command" },
-                            ...devices.map((d) => ({
-                              value: d.id,
-                              label: d.name,
-                            })),
-                          ]}
-                          value={deviceId}
-                          onChange={(value) => {
-                            setDeviceId(value);
-                            // Clear protocol if it's not available for the new device
-                            if (value) {
-                              const device = devices.find(
-                                (d) => d.id === value,
-                              );
-                              const linkedProtocolIds =
-                                device?.protocols?.map((p) => p.protocolId) ||
-                                [];
-                              if (
-                                protocolId &&
-                                !linkedProtocolIds.includes(protocolId)
-                              ) {
-                                // Set to device's default protocol or clear
-                                setProtocolId(device?.defaultProtocolId || "");
-                              }
-                            }
-                          }}
-                          placeholder="Select device..."
-                        />
-                        {deviceId && (
-                          <Link
-                            to={`/devices/${deviceId}/edit`}
-                            className="shrink-0"
-                            title="Edit device"
-                          >
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              className="h-9 w-9"
-                            >
-                              <ExternalLink className="h-4 w-4" />
-                            </Button>
-                          </Link>
-                        )}
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label className="flex items-center gap-1.5">
-                        <Layers className="w-3.5 h-3.5 text-muted-foreground" />
-                        Protocol
-                      </Label>
-                      <div className="flex items-center gap-2">
-                        <SelectDropdown
-                          options={[
-                            { value: "", label: "None" },
-                            ...availableProtocols.map((p) => ({
-                              value: p.id,
-                              label: `${p.name} (v${p.version})`,
-                            })),
-                          ]}
-                          value={protocolId}
-                          onChange={setProtocolId}
-                          placeholder="Select protocol..."
-                        />
-                        {protocolId && (
-                          <Link
-                            to={`/protocols/${protocolId}/edit`}
-                            className="shrink-0"
-                            title="Edit protocol"
-                          >
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon"
-                              className="h-9 w-9"
-                            >
-                              <ExternalLink className="h-4 w-4" />
-                            </Button>
-                          </Link>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                  {deviceId && (
-                    <p className="text-[10px] text-muted-foreground">
-                      Commands linked to a device appear in that device&apos;s
-                      command list.
-                    </p>
-                  )}
-                </div>
-
-                {/* Command Source Selection */}
-                <div className="p-4 bg-muted/20 rounded-lg border border-border/50 space-y-4">
-                  <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground uppercase">
-                    <FileCode className="w-3.5 h-3.5" />
-                    Command Source
-                  </div>
-                  <div className="grid grid-cols-2 gap-3">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setSource("CUSTOM");
-                        setTemplateId("");
-                      }}
-                      className={cn(
-                        "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
-                        source === "CUSTOM"
-                          ? "bg-primary/5 border-primary shadow-sm"
-                          : "bg-card border-border/50",
-                      )}
-                    >
-                      <FileCode className="w-5 h-5 text-orange-500" />
-                      <span className="font-semibold text-sm">
-                        Custom Command
-                      </span>
-                      <span className="text-[10px] text-muted-foreground text-center">
-                        Manually define payload
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setSource("PROTOCOL")}
-                      className={cn(
-                        "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
-                        source === "PROTOCOL"
-                          ? "bg-primary/5 border-primary shadow-sm"
-                          : "bg-card border-border/50",
-                      )}
-                    >
-                      <Layers className="w-5 h-5 text-blue-500" />
-                      <span className="font-semibold text-sm">
-                        From Template
-                      </span>
-                      <span className="text-[10px] text-muted-foreground text-center">
-                        Use protocol template
-                      </span>
-                    </button>
-                  </div>
-
-                  {/* Template Picker - shown when PROTOCOL source is selected */}
-                  {source === "PROTOCOL" && (
-                    <div className="space-y-3 pt-2 border-t border-border/50">
-                      {!protocolId ? (
-                        <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg text-xs text-blue-600 dark:text-blue-400 flex items-start gap-2">
-                          <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
-                          <span>
-                            Please select a protocol first to see available
-                            templates
-                          </span>
-                        </div>
-                      ) : availableTemplates.length === 0 ? (
-                        <div className="p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg text-xs text-yellow-600 dark:text-yellow-400 flex items-start gap-2">
-                          <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
-                          <span>
-                            No command templates available for{" "}
-                            {protocols.find((p) => p.id === protocolId)?.name ??
-                              "unknown protocol"}
-                          </span>
-                        </div>
-                      ) : (
-                        <>
-                          <div className="space-y-2">
-                            <Label className="text-xs">
-                              Command Template{" "}
-                              <span className="text-destructive">*</span>
-                            </Label>
-                            <SelectDropdown
-                              options={availableTemplates.map((t) => ({
-                                value: t.id,
-                                label: `${t.name} - ${t.description || ""}`,
-                              }))}
-                              value={templateId}
-                              onChange={(value) => {
-                                setTemplateId(value);
-                                // Initialize parameter values from template defaults
-                                const template = availableTemplates.find(
-                                  (t) => t.id === value,
-                                );
-                                if (template?.parameters) {
-                                  const defaultValues: Record<string, any> = {};
-                                  template.parameters.forEach((param) => {
-                                    if (param.defaultValue !== undefined) {
-                                      defaultValues[param.name] =
-                                        param.defaultValue;
-                                    }
-                                  });
-                                  setParameterValues(defaultValues);
-                                }
-                              }}
-                              placeholder="Select a template..."
-                            />
-                          </div>
-
-                          {/* Template Preview */}
-                          {selectedTemplate && (
-                            <div className="space-y-2">
-                              <Label className="text-xs text-muted-foreground">
-                                Template Payload
-                              </Label>
-                              <div className="p-3 bg-muted/30 rounded-lg border border-border/50">
-                                <code className="text-xs font-mono text-blue-600 dark:text-blue-400">
-                                  {selectedTemplate.payload}
-                                </code>
-                              </div>
-                              {selectedTemplate.description && (
-                                <p className="text-[10px] text-muted-foreground">
-                                  {selectedTemplate.description}
-                                </p>
-                              )}
-                            </div>
-                          )}
-
-                          {/* Computed Payload Preview */}
-                          {selectedTemplate &&
-                            Object.keys(parameterValues).length > 0 && (
-                              <div className="space-y-2">
-                                <div className="flex items-center gap-2">
-                                  <Label className="text-xs text-muted-foreground">
-                                    Computed Payload
-                                  </Label>
-                                  <Info className="w-3 h-3 text-muted-foreground" />
-                                </div>
-                                <div className="p-3 bg-green-500/10 rounded-lg border border-green-500/20">
-                                  <code className="text-xs font-mono text-green-600 dark:text-green-400">
-                                    {(() => {
-                                      try {
-                                        return substituteParameters(
-                                          selectedTemplate.payload,
-                                          parameterValues,
-                                          selectedTemplate.parameters || [],
-                                        );
-                                      } catch (e) {
-                                        return "Error computing payload";
-                                      }
-                                    })()}
-                                  </code>
-                                </div>
-                                <p className="text-[10px] text-muted-foreground">
-                                  This is the final payload that will be sent
-                                  with your current parameter values
-                                </p>
-                              </div>
-                            )}
-
-                          {/* Dynamic Parameter Inputs */}
-                          {selectedTemplate?.parameters &&
-                            selectedTemplate.parameters.length > 0 && (
-                              <div className="space-y-3 pt-2 border-t border-border/50">
-                                <div className="flex items-center justify-between">
-                                  <Label className="text-xs font-semibold">
-                                    Template Parameters
-                                  </Label>
-                                  <Badge
-                                    variant="outline"
-                                    className="text-[10px]"
-                                  >
-                                    {selectedTemplate.parameters.length}{" "}
-                                    parameter
-                                    {selectedTemplate.parameters.length !== 1
-                                      ? "s"
-                                      : ""}
-                                  </Badge>
-                                </div>
-
-                                {selectedTemplate.parameters.map((param) => (
-                                  <div key={param.name} className="space-y-2">
-                                    <Label className="text-xs">
-                                      {param.label || param.name}
-                                      {param.required && (
-                                        <span className="text-destructive">
-                                          {" "}
-                                          *
-                                        </span>
-                                      )}
-                                    </Label>
-
-                                    {/* STRING input */}
-                                    {param.type === "STRING" && (
-                                      <div className="relative">
-                                        <Input
-                                          value={
-                                            parameterValues[param.name] ??
-                                            param.defaultValue ??
-                                            ""
-                                          }
-                                          onChange={(e) =>
-                                            setParameterValues((prev) => ({
-                                              ...prev,
-                                              [param.name]: e.target.value,
-                                            }))
-                                          }
-                                          placeholder={param.placeholder}
-                                          maxLength={param.maxLength}
-                                          className={cn(
-                                            "h-8 text-xs font-mono pr-8",
-                                            param.required &&
-                                              !parameterValues[param.name] &&
-                                              "border-destructive",
-                                          )}
-                                        />
-                                        {param.required &&
-                                          parameterValues[param.name] && (
-                                            <Check className="absolute right-2 top-2 w-4 h-4 text-green-500" />
-                                          )}
-                                      </div>
-                                    )}
-
-                                    {/* INTEGER input */}
-                                    {param.type === "INTEGER" && (
-                                      <div className="relative">
-                                        <Input
-                                          type="number"
-                                          value={
-                                            parameterValues[param.name] ??
-                                            param.defaultValue ??
-                                            ""
-                                          }
-                                          onChange={(e) =>
-                                            setParameterValues((prev) => ({
-                                              ...prev,
-                                              [param.name]: parseInt(
-                                                e.target.value,
-                                              ),
-                                            }))
-                                          }
-                                          min={param.min}
-                                          max={param.max}
-                                          className={cn(
-                                            "h-8 text-xs font-mono pr-8",
-                                            param.required &&
-                                              parameterValues[param.name] ===
-                                                undefined &&
-                                              "border-destructive",
-                                          )}
-                                        />
-                                        {param.required &&
-                                          parameterValues[param.name] !==
-                                            undefined && (
-                                            <Check className="absolute right-2 top-2 w-4 h-4 text-green-500" />
-                                          )}
-                                      </div>
-                                    )}
-
-                                    {/* FLOAT input */}
-                                    {param.type === "FLOAT" && (
-                                      <div className="relative">
-                                        <Input
-                                          type="number"
-                                          step="any"
-                                          value={
-                                            parameterValues[param.name] ??
-                                            param.defaultValue ??
-                                            ""
-                                          }
-                                          onChange={(e) =>
-                                            setParameterValues((prev) => ({
-                                              ...prev,
-                                              [param.name]: parseFloat(
-                                                e.target.value,
-                                              ),
-                                            }))
-                                          }
-                                          min={param.min}
-                                          max={param.max}
-                                          className={cn(
-                                            "h-8 text-xs font-mono pr-8",
-                                            param.required &&
-                                              parameterValues[param.name] ===
-                                                undefined &&
-                                              "border-destructive",
-                                          )}
-                                        />
-                                        {param.required &&
-                                          parameterValues[param.name] !==
-                                            undefined && (
-                                            <Check className="absolute right-2 top-2 w-4 h-4 text-green-500" />
-                                          )}
-                                      </div>
-                                    )}
-
-                                    {/* ENUM dropdown */}
-                                    {param.type === "ENUM" && param.options && (
-                                      <SelectDropdown
-                                        options={param.options.map((opt) => ({
-                                          label: opt.label || String(opt.value),
-                                          value: opt.value || "",
-                                        }))}
-                                        value={
-                                          parameterValues[param.name] ??
-                                          param.defaultValue ??
-                                          ""
-                                        }
-                                        onChange={(value) =>
-                                          setParameterValues((prev) => ({
-                                            ...prev,
-                                            [param.name]: value,
-                                          }))
-                                        }
-                                      />
-                                    )}
-
-                                    {/* BOOLEAN checkbox */}
-                                    {param.type === "BOOLEAN" && (
-                                      <div className="flex items-center gap-2">
-                                        <Checkbox
-                                          checked={
-                                            parameterValues[param.name] ??
-                                            param.defaultValue ??
-                                            false
-                                          }
-                                          onChange={(e) =>
-                                            setParameterValues((prev) => ({
-                                              ...prev,
-                                              [param.name]: e.target.checked,
-                                            }))
-                                          }
-                                        />
-                                        <span className="text-xs text-muted-foreground">
-                                          {param.description}
-                                        </span>
-                                      </div>
-                                    )}
-
-                                    {/* Enhanced Parameter Help */}
-                                    {param.type !== "BOOLEAN" && (
-                                      <div className="space-y-1">
-                                        {param.description && (
-                                          <p className="text-[10px] text-muted-foreground">
-                                            {param.description}
-                                          </p>
-                                        )}
-                                        <div className="flex flex-wrap gap-2 text-[9px] text-muted-foreground">
-                                          {param.defaultValue !== undefined && (
-                                            <span className="inline-flex items-center gap-1">
-                                              <span className="font-semibold">
-                                                Default:
-                                              </span>
-                                              <code className="px-1 py-0.5 bg-muted rounded">
-                                                {String(param.defaultValue)}
-                                              </code>
-                                            </span>
-                                          )}
-                                          {param.type === "INTEGER" &&
-                                            (param.min !== undefined ||
-                                              param.max !== undefined) && (
-                                              <span className="inline-flex items-center gap-1">
-                                                <span className="font-semibold">
-                                                  Range:
-                                                </span>
-                                                <code className="px-1 py-0.5 bg-muted rounded">
-                                                  {param.min ?? "-∞"} to{" "}
-                                                  {param.max ?? "∞"}
-                                                </code>
-                                              </span>
-                                            )}
-                                          {param.type === "FLOAT" &&
-                                            (param.min !== undefined ||
-                                              param.max !== undefined) && (
-                                              <span className="inline-flex items-center gap-1">
-                                                <span className="font-semibold">
-                                                  Range:
-                                                </span>
-                                                <code className="px-1 py-0.5 bg-muted rounded">
-                                                  {param.min ?? "-∞"} to{" "}
-                                                  {param.max ?? "∞"}
-                                                </code>
-                                              </span>
-                                            )}
-                                          {param.type === "STRING" &&
-                                            param.maxLength && (
-                                              <span className="inline-flex items-center gap-1">
-                                                <span className="font-semibold">
-                                                  Max length:
-                                                </span>
-                                                <code className="px-1 py-0.5 bg-muted rounded">
-                                                  {param.maxLength}
-                                                </code>
-                                              </span>
-                                            )}
-                                          {param.required && (
-                                            <Badge
-                                              variant="destructive"
-                                              className="text-[8px] h-4 px-1.5"
-                                            >
-                                              Required
-                                            </Badge>
-                                          )}
-                                        </div>
-                                      </div>
-                                    )}
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-                        </>
-                      )}
-                    </div>
-                  )}
-                </div>
-
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
-                    <Label>{t("cmd.name")}</Label>
-                    <Input
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>{t("cmd.group")}</Label>
-                    <Input
-                      value={group}
-                      onChange={(e) => setGroup(e.target.value)}
-                      placeholder="Device Name"
-                    />
-                  </div>
-                </div>
-                {/* Format and Encoding - only for CUSTOM commands */}
-                {source === "CUSTOM" && (
-                  <>
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-2">
-                        <Label>{t("cmd.format")}</Label>
-                        <SelectDropdown
-                          options={
-                            [
-                              { value: "TEXT", label: "TEXT" },
-                              { value: "HEX", label: "HEX" },
-                            ] as DropdownOption<DataMode>[]
-                          }
-                          value={mode}
-                          onChange={(value) => setMode(value)}
-                        />
-                      </div>
-                      {mode === "TEXT" && (
-                        <div className="space-y-2">
-                          <Label>Encoding</Label>
-                          <SelectDropdown
-                            options={
-                              [
-                                { value: "UTF-8", label: "UTF-8" },
-                                { value: "ASCII", label: "ASCII" },
-                              ] as DropdownOption<TextEncoding>[]
-                            }
-                            value={encoding}
-                            onChange={(value) => setEncoding(value)}
-                          />
-                        </div>
-                      )}
-                    </div>
-                    <div className="space-y-2">
-                      <Label>{t("cmd.payload")}</Label>
-                      <Textarea
-                        value={payload}
-                        onChange={(e) => setPayload(e.target.value)}
-                        className="font-mono text-xs"
-                      />
-                    </div>
-                  </>
-                )}
-              </CardContent>
+              <BasicTab
+                name={name}
+                onNameChange={setName}
+                group={group}
+                onGroupChange={setGroup}
+                deviceId={deviceId}
+                onDeviceIdChange={setDeviceId}
+                protocolId={protocolId}
+                onProtocolIdChange={setProtocolId}
+                devices={devices}
+                availableProtocols={availableProtocols}
+                source={source}
+                onSourceChange={setSource}
+                templateId={templateId}
+                onTemplateIdChange={setTemplateId}
+                availableTemplates={availableTemplates}
+                selectedTemplate={selectedTemplate}
+                parameterValues={parameterValues}
+                onParameterValuesChange={setParameterValues}
+                protocols={protocols}
+                mode={mode}
+                onModeChange={setMode}
+                encoding={encoding}
+                onEncodingChange={setEncoding}
+                payload={payload}
+                onPayloadChange={setPayload}
+                t={t}
+              />
             )}
 
             {activeTab === "params" && (
-              <CardContent className="pt-6 space-y-4">
-                <div className="flex justify-between items-center">
-                  <div className="text-sm text-muted-foreground">
-                    Define variables to be used in scripting.
-                  </div>
-                  <Button
-                    type="button"
-                    size="sm"
-                    onClick={addParameter}
-                    variant="outline"
-                    className="h-8 gap-1"
-                  >
-                    <Plus className="w-3.5 h-3.5" /> Add Parameter
-                  </Button>
-                </div>
-
-                <div className="space-y-3">
-                  {parameters.length === 0 && (
-                    <div className="text-center py-10 text-muted-foreground italic bg-muted/20 rounded-lg">
-                      No parameters defined.
-                    </div>
-                  )}
-                  {parameters.map((param, idx) => (
-                    <div
-                      key={param.id}
-                      className="p-3 border rounded-lg bg-card grid grid-cols-12 gap-3 items-end animate-in fade-in slide-in-from-bottom-2"
-                    >
-                      <div className="col-span-3 space-y-1">
-                        <Label className="text-[10px]">Var Name</Label>
-                        <Input
-                          value={param.name}
-                          onChange={(e) =>
-                            updateParameter(idx, { name: e.target.value })
-                          }
-                          className="h-8 text-xs font-mono"
-                          placeholder="varName"
-                        />
-                      </div>
-                      <div className="col-span-3 space-y-1">
-                        <Label className="text-[10px]">Label</Label>
-                        <Input
-                          value={param.label || ""}
-                          onChange={(e) =>
-                            updateParameter(idx, { label: e.target.value })
-                          }
-                          className="h-8 text-xs"
-                          placeholder="Display Label"
-                        />
-                      </div>
-                      <div className="col-span-2 space-y-1">
-                        <Label className="text-[10px]">Type</Label>
-                        <SelectDropdown
-                          options={
-                            [
-                              { value: "STRING", label: "String" },
-                              { value: "INTEGER", label: "Integer" },
-                              { value: "FLOAT", label: "Float" },
-                              { value: "BOOLEAN", label: "Boolean" },
-                            ] as DropdownOption<ParameterType>[]
-                          }
-                          value={param.type}
-                          onChange={(value) =>
-                            updateParameter(idx, { type: value })
-                          }
-                          size="sm"
-                        />
-                      </div>
-                      <div className="col-span-3 space-y-1">
-                        <Label className="text-[10px]">Default</Label>
-                        <Input
-                          value={String(param.defaultValue ?? "")}
-                          onChange={(e) =>
-                            updateParameter(idx, {
-                              defaultValue: e.target.value,
-                            })
-                          }
-                          className="h-8 text-xs"
-                          placeholder="Optional"
-                        />
-                      </div>
-                      <div className="col-span-1">
-                        <Button
-                          type="button"
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => removeParameter(idx)}
-                          className="h-8 w-8 text-destructive hover:bg-destructive/10"
-                        >
-                          <Trash2 className="w-3.5 h-3.5" />
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
+              <ParametersTab
+                parameters={parameters}
+                onAdd={addParameter}
+                onUpdate={updateParameter}
+                onRemove={removeParameter}
+              />
             )}
 
             {activeTab === "processing" && (
-              <CardContent className="pt-6 space-y-8 h-full flex flex-col">
-                <div className="space-y-3">
-                  <Checkbox
-                    checked={preRequestEnabled}
-                    onChange={(e) => setPreRequestEnabled(e.target.checked)}
-                    label="Enable Pre-Request Handling"
-                    labelClassName="font-bold text-sm"
-                  />
-                  {preRequestEnabled && (
-                    <div className="pl-6 space-y-2 animate-in slide-in-from-top-1">
-                      <CodeEditor
-                        value={preRequestScript}
-                        onChange={setPreRequestScript}
-                        height="120px"
-                        className="border-l-4 border-l-blue-500/30"
-                      />
-                      <p className="text-[10px] text-muted-foreground italic">
-                        Modify payload before transmission. Variables available:{" "}
-                        <code>payload</code>, <code>params</code>.
-                      </p>
-                    </div>
-                  )}
-                </div>
-
-                <div className="space-y-4">
-                  <Checkbox
-                    checked={postResponseEnabled}
-                    onChange={(e) => setPostResponseEnabled(e.target.checked)}
-                    label="Enable Post-Response Handling"
-                    labelClassName="font-bold text-sm"
-                  />
-
-                  {postResponseEnabled && (
-                    <div className="pl-6 space-y-4 animate-in slide-in-from-top-1">
-                      <div className="grid grid-cols-2 gap-3">
-                        <div
-                          onClick={() => setResponseMode("PATTERN")}
-                          className={cn(
-                            "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
-                            responseMode === "PATTERN"
-                              ? "bg-primary/5 border-primary shadow-sm ring-1 ring-primary/20"
-                              : "bg-card",
-                          )}
-                        >
-                          <Search
-                            className={cn(
-                              "w-5 h-5",
-                              responseMode === "PATTERN"
-                                ? "text-primary"
-                                : "text-muted-foreground",
-                            )}
-                          />
-                          <div className="text-center">
-                            <div className="font-bold text-xs">
-                              Simple Pattern
-                            </div>
-                            <div className="text-[9px] text-muted-foreground mt-0.5">
-                              Success on string match
-                            </div>
-                          </div>
-                        </div>
-                        <div
-                          onClick={() => setResponseMode("SCRIPT")}
-                          className={cn(
-                            "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
-                            responseMode === "SCRIPT"
-                              ? "bg-primary/5 border-primary shadow-sm ring-1 ring-primary/20"
-                              : "bg-card",
-                          )}
-                        >
-                          <FileCode
-                            className={cn(
-                              "w-5 h-5",
-                              responseMode === "SCRIPT"
-                                ? "text-primary"
-                                : "text-muted-foreground",
-                            )}
-                          />
-                          <div className="text-center">
-                            <div className="font-bold text-xs">
-                              Advanced Script
-                            </div>
-                            <div className="text-[9px] text-muted-foreground mt-0.5">
-                              JS logic & extraction
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      {responseMode === "PATTERN" ? (
-                        <div className="p-4 bg-muted/20 border border-border rounded-lg grid grid-cols-3 gap-4 animate-in fade-in">
-                          <div className="space-y-1">
-                            <Label className="text-[10px]">Type</Label>
-                            <SelectDropdown
-                              options={
-                                [
-                                  { value: "CONTAINS", label: "Contains" },
-                                  { value: "REGEX", label: "Regex" },
-                                ] as DropdownOption<MatchType>[]
-                              }
-                              value={matchType}
-                              onChange={(value) => setMatchType(value)}
-                              size="sm"
-                            />
-                          </div>
-                          <div className="col-span-2 space-y-1">
-                            <Label className="text-[10px]">Pattern</Label>
-                            <Input
-                              className="h-8 text-xs font-mono"
-                              value={pattern}
-                              onChange={(e) => setPattern(e.target.value)}
-                              placeholder="OK"
-                            />
-                          </div>
-                          <div className="space-y-1">
-                            <Label className="text-[10px]">Timeout (ms)</Label>
-                            <Input
-                              type="number"
-                              className="h-8 text-xs"
-                              value={timeout}
-                              onChange={(e) =>
-                                setTimeoutVal(parseInt(e.target.value))
-                              }
-                            />
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="space-y-2 animate-in fade-in">
-                          <CodeEditor
-                            value={postResponseScript}
-                            onChange={setPostResponseScript}
-                            height="150px"
-                            className="border-l-4 border-l-emerald-500/30"
-                          />
-                          <p className="text-[10px] text-muted-foreground italic">
-                            Validate and extract data. Variables:{" "}
-                            <code>data</code>, <code>raw</code>,{" "}
-                            <code>setVar</code>, <code>log</code>.
-                          </p>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </CardContent>
+              <ProcessingTab
+                preRequestEnabled={preRequestEnabled}
+                onPreRequestEnabledChange={setPreRequestEnabled}
+                preRequestScript={preRequestScript}
+                onPreRequestScriptChange={setPreRequestScript}
+                postResponseEnabled={postResponseEnabled}
+                onPostResponseEnabledChange={setPostResponseEnabled}
+                responseMode={responseMode}
+                onResponseModeChange={setResponseMode}
+                matchType={matchType}
+                onMatchTypeChange={setMatchType}
+                pattern={pattern}
+                onPatternChange={setPattern}
+                timeout={timeout}
+                onTimeoutChange={setTimeoutVal}
+                postResponseScript={postResponseScript}
+                onPostResponseScriptChange={setPostResponseScript}
+              />
             )}
 
             {activeTab === "framing" && (
-              <CardContent className="pt-6 space-y-6">
-                <div className="p-3 bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800 rounded-md flex gap-2">
-                  <AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-500 shrink-0 mt-0.5" />
-                  <div className="text-xs text-amber-800 dark:text-amber-300">
-                    <strong>Note:</strong> Framing overrides allow this specific
-                    command to parse incoming data differently (e.g., waiting
-                    for a specific delimiter).
-                  </div>
-                </div>
-
-                <div className="flex items-center justify-between">
-                  <Checkbox
-                    checked={framingEnabled}
-                    onChange={(e) => setFramingEnabled(e.target.checked)}
-                    label="Override Global Framing"
-                    labelClassName="font-bold"
-                  />
-                  {framingEnabled && (
-                    <SelectDropdown
-                      options={
-                        [
-                          { value: "TRANSIENT", label: "Transient (One-Shot)" },
-                          {
-                            value: "PERSISTENT",
-                            label: "Persistent (Change Global)",
-                          },
-                        ] as DropdownOption<"TRANSIENT" | "PERSISTENT">[]
-                      }
-                      value={framingPersistence}
-                      onChange={(value) => setFramingPersistence(value)}
-                      size="sm"
-                      className="w-45"
-                    />
-                  )}
-                </div>
-
-                {framingEnabled && (
-                  <div className="pl-6 space-y-4 animate-in slide-in-from-top-2 border-l-2 border-border ml-2">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-1">
-                        <Label className="text-xs">Strategy</Label>
-                        <SelectDropdown
-                          options={
-                            [
-                              { value: "NONE", label: "None (Raw Stream)" },
-                              { value: "DELIMITER", label: "Delimiter" },
-                              { value: "TIMEOUT", label: "Timeout" },
-                              {
-                                value: "PREFIX_LENGTH",
-                                label: "Prefix Length",
-                              },
-                              { value: "SCRIPT", label: "Custom Script" },
-                            ] as DropdownOption<FramingStrategy>[]
-                          }
-                          value={framingConfig.strategy}
-                          onChange={(newStrategy) => {
-                            let newScript = framingConfig.script;
-
-                            // Add default script example if switching to SCRIPT mode and it's empty
-                            if (
-                              newStrategy === "SCRIPT" &&
-                              (!newScript || newScript.trim() === "")
-                            ) {
-                              newScript = `// Custom Framer Script
-// Args: chunks (Array<{data: Uint8Array, timestamp: number}>), forceFlush (boolean)
-// Return: { frames: [], remaining: [] }
-
-// Example: Merge everything into one frame on timeout/flush
-if (forceFlush) {
-    const totalLen = chunks.reduce((acc, c) => acc + c.data.length, 0);
-    const merged = new Uint8Array(totalLen);
-    let offset = 0;
-    for(const c of chunks) {
-        merged.set(c.data, offset);
-        offset += c.data.length;
-    }
-    // Return single combined frame
-    return {
-        frames: [{ data: merged, timestamp: Date.now() }],
-        remaining: []
-    };
-}
-
-// Keep accumulating if not flushed
-return { frames: [], remaining: chunks };`;
-                            }
-
-                            setFramingConfig({
-                              ...framingConfig,
-                              strategy: newStrategy,
-                              script: newScript,
-                            });
-                          }}
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs">Timeout (ms)</Label>
-                        <Input
-                          type="number"
-                          value={framingConfig.timeout}
-                          onChange={(e) =>
-                            setFramingConfig({
-                              ...framingConfig,
-                              timeout: parseInt(e.target.value),
-                            })
-                          }
-                          className="h-9 text-sm"
-                        />
-                      </div>
-                    </div>
-
-                    {framingConfig.strategy === "DELIMITER" && (
-                      <div className="space-y-1">
-                        <Label className="text-xs">Delimiter (Hex/Text)</Label>
-                        <Input
-                          value={framingConfig.delimiter}
-                          onChange={(e) =>
-                            setFramingConfig({
-                              ...framingConfig,
-                              delimiter: e.target.value,
-                            })
-                          }
-                          placeholder="e.g. \n or 0D 0A"
-                          className="h-9 text-sm font-mono"
-                        />
-                      </div>
-                    )}
-
-                    {framingConfig.strategy === "PREFIX_LENGTH" && (
-                      <div className="grid grid-cols-2 gap-4">
-                        <div className="space-y-1">
-                          <Label className="text-xs">Header Size (Bytes)</Label>
-                          <Input
-                            type="number"
-                            min={1}
-                            max={8}
-                            value={framingConfig.prefixLengthSize}
-                            onChange={(e) =>
-                              setFramingConfig({
-                                ...framingConfig,
-                                prefixLengthSize: parseInt(e.target.value),
-                              })
-                            }
-                            className="h-9 text-sm"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-xs">Byte Order</Label>
-                          <SelectDropdown
-                            options={
-                              [
-                                { value: "LE", label: "Little Endian" },
-                                { value: "BE", label: "Big Endian" },
-                              ] as DropdownOption<"LE" | "BE">[]
-                            }
-                            value={framingConfig.byteOrder}
-                            onChange={(value) =>
-                              setFramingConfig({
-                                ...framingConfig,
-                                byteOrder: value,
-                              })
-                            }
-                          />
-                        </div>
-                      </div>
-                    )}
-
-                    {framingConfig.strategy === "SCRIPT" && (
-                      <div className="space-y-1">
-                        <Label className="text-xs">Framer Script</Label>
-                        <CodeEditor
-                          value={framingConfig.script || ""}
-                          onChange={(val) =>
-                            setFramingConfig({ ...framingConfig, script: val })
-                          }
-                          height="150px"
-                          className="border-l-4 border-l-purple-500/30"
-                        />
-                      </div>
-                    )}
-                  </div>
-                )}
-              </CardContent>
+              <FramingTab
+                framingEnabled={framingEnabled}
+                onFramingEnabledChange={setFramingEnabled}
+                framingConfig={framingConfig}
+                onFramingConfigChange={setFramingConfig}
+                framingPersistence={framingPersistence}
+                onFramingPersistenceChange={setFramingPersistence}
+              />
             )}
 
             {activeTab === "context" && (
-              <CardContent className="pt-6 space-y-4 h-full flex flex-col">
-                <div className="flex items-end gap-2">
-                  <div className="space-y-1 flex-1">
-                    <Label>Context ID / Link</Label>
-                    <div className="space-y-2">
-                      {contexts.map((context) => (
-                        <Checkbox
-                          key={context.id}
-                          checked={contextIds.includes(context.id)}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              setContextIds([...contextIds, context.id]);
-                            } else {
-                              setContextIds(
-                                contextIds.filter((id) => id !== context.id),
-                              );
-                            }
-                          }}
-                          label={context.title}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    onClick={() => {
-                      if (contextTitle && contextContent) {
-                        if (
-                          contextIds.length === 1 &&
-                          activeContexts.length === 1
-                        ) {
-                          if (onUpdateContext)
-                            onUpdateContext({
-                              ...activeContexts[0],
-                              title: contextTitle,
-                              content: contextContent,
-                            });
-                        } else {
-                          const newCtx = {
-                            id: generateId(),
-                            title: contextTitle,
-                            content: contextContent,
-                            source: "USER" as const,
-                            createdAt: Date.now(),
-                          };
-                          onCreateContext(newCtx);
-                          setContextIds([...contextIds, newCtx.id]);
-                        }
-                      }
-                    }}
-                  >
-                    Save Context
-                  </Button>
-                </div>
-
-                <div className="space-y-1">
-                  <Label>Context Title</Label>
-                  <Input
-                    value={contextTitle}
-                    onChange={(e) => setContextTitle(e.target.value)}
-                    placeholder="Protocol Manual Section 1..."
-                  />
-                </div>
-
-                <div className="space-y-1 flex-1 flex flex-col">
-                  <Label>Content (Markdown/Text)</Label>
-                  <Textarea
-                    value={contextContent}
-                    onChange={(e) => setContextContent(e.target.value)}
-                    className="flex-1 resize-none font-mono text-xs"
-                    placeholder="Paste documentation or protocol details here..."
-                  />
-                </div>
-              </CardContent>
+              <ContextTab
+                contexts={contexts}
+                contextIds={contextIds}
+                onContextIdsChange={setContextIds}
+                contextTitle={contextTitle}
+                onContextTitleChange={setContextTitle}
+                contextContent={contextContent}
+                onContextContentChange={setContextContent}
+                onUpdateContext={onUpdateContext}
+                onCreateContext={onCreateContext}
+              />
             )}
 
             {activeTab === "protocol" && (
-              <CardContent className="pt-6 space-y-6">
-                <div className="grid grid-cols-2 gap-4">
-                  <div
-                    onClick={() => setProtoType("MODBUS")}
-                    className={cn(
-                      "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
-                      protoType === "MODBUS"
-                        ? "bg-primary/5 border-primary shadow-sm"
-                        : "bg-card",
-                    )}
-                  >
-                    <Calculator className="w-6 h-6 text-blue-500" />
-                    <span className="font-bold text-sm">
-                      Modbus RTU Generator
-                    </span>
-                  </div>
-                  <div
-                    onClick={() => setProtoType("AT")}
-                    className={cn(
-                      "p-4 border rounded-xl flex flex-col items-center gap-2 cursor-pointer transition-all hover:bg-muted/30",
-                      protoType === "AT"
-                        ? "bg-primary/5 border-primary shadow-sm"
-                        : "bg-card",
-                    )}
-                  >
-                    <Terminal className="w-6 h-6 text-emerald-500" />
-                    <span className="font-bold text-sm">
-                      AT Command Library
-                    </span>
-                  </div>
-                </div>
-
-                {protoType === "MODBUS" && (
-                  <div className="space-y-4 p-4 border rounded-lg bg-muted/10 animate-in fade-in">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div className="space-y-1">
-                        <Label className="text-xs">Slave ID</Label>
-                        <Input
-                          type="number"
-                          value={mbParams.slaveId}
-                          onChange={(e) =>
-                            setMbParams({
-                              ...mbParams,
-                              slaveId: parseInt(e.target.value),
-                            })
-                          }
-                          className="h-8"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs">Function</Label>
-                        <SelectDropdown
-                          options={MODBUS_FUNCTIONS.map(
-                            (f): DropdownOption<number> => ({
-                              value: f.code,
-                              label: f.name,
-                            }),
-                          )}
-                          value={mbParams.functionCode}
-                          onChange={(value) =>
-                            setMbParams({
-                              ...mbParams,
-                              functionCode: value,
-                            })
-                          }
-                          size="sm"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs">Start Address</Label>
-                        <Input
-                          type="number"
-                          value={mbParams.startAddress}
-                          onChange={(e) =>
-                            setMbParams({
-                              ...mbParams,
-                              startAddress: parseInt(e.target.value),
-                            })
-                          }
-                          className="h-8"
-                        />
-                      </div>
-                      <div className="space-y-1">
-                        <Label className="text-xs">Quantity/Value</Label>
-                        <Input
-                          type="number"
-                          value={mbParams.quantityOrValue}
-                          onChange={(e) =>
-                            setMbParams({
-                              ...mbParams,
-                              quantityOrValue: parseInt(e.target.value),
-                            })
-                          }
-                          className="h-8"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-2">
-                      <code className="flex-1 bg-background border p-2 rounded text-xs font-mono">
-                        {generateModbusFrame(mbParams)}
-                      </code>
-                      <Button
-                        size="sm"
-                        type="button"
-                        onClick={() => {
-                          setMode("HEX");
-                          setPayload(generateModbusFrame(mbParams));
-                          setActiveTab("basic");
-                        }}
-                      >
-                        Use Payload
-                      </Button>
-                    </div>
-                  </div>
-                )}
-
-                {protoType === "AT" && (
-                  <div className="space-y-4 p-4 border rounded-lg bg-muted/10 animate-in fade-in">
-                    <div className="space-y-2">
-                      <Label>Common AT Commands</Label>
-                      <div className="h-50 overflow-y-auto border rounded bg-background p-2 space-y-1">
-                        {Object.entries(AT_COMMAND_LIBRARY).map(
-                          ([cat, cmds]) => (
-                            <div key={cat} className="mb-2">
-                              <div className="text-[10px] font-bold text-muted-foreground uppercase mb-1 sticky top-0 bg-background">
-                                {cat}
-                              </div>
-                              {cmds.map((c) => (
-                                <div
-                                  key={c.cmd}
-                                  className="flex justify-between items-center p-1.5 hover:bg-muted rounded cursor-pointer group"
-                                  onClick={() => {
-                                    setMode("TEXT");
-                                    setPayload(c.cmd);
-                                    setDescription(c.desc);
-                                    setActiveTab("basic");
-                                  }}
-                                >
-                                  <code className="text-xs font-bold text-primary">
-                                    {c.cmd}
-                                  </code>
-                                  <span className="text-[10px] text-muted-foreground">
-                                    {c.desc}
-                                  </span>
-                                </div>
-                              ))}
-                            </div>
-                          ),
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </CardContent>
+              <ProtocolTab
+                protoType={protoType}
+                onProtoTypeChange={setProtoType}
+                mbParams={mbParams}
+                onMbParamsChange={setMbParams}
+                onUsePayload={handleUsePayload}
+              />
             )}
           </div>
           <CardFooter className="flex justify-end bg-muted/20 border-t border-border p-4 gap-2">


### PR DESCRIPTION
## Summary

- **Splits the 1717-line `CommandFormModal.tsx` god component** into a container + 6 focused tab components under `src/components/CommandForm/`
- Container (`CommandFormModal.tsx`, 524 lines) retains state management, submit logic, and tab routing
- Each tab is a self-contained presentational component with explicit props:
  - `BasicTab.tsx` (652 lines) — device/protocol selection, command source, template picker, payload
  - `ParametersTab.tsx` (115 lines) — command parameter definition
  - `ProcessingTab.tsx` (192 lines) — pre-request/post-response scripting
  - `FramingTab.tsx` (217 lines) — response framing override configuration
  - `ContextTab.tsx` (110 lines) — context linking and editing
  - `ProtocolTab.tsx` (177 lines) — Modbus RTU / AT command protocol wizard
- Uses `SimpleCommand`/`SimpleParameter` types from `protocolTypes` for type safety in template parameter inputs

## Test plan

- [x] Open command form modal — verify all 6 tabs render correctly
- [x] Create a CUSTOM command — verify payload, mode, encoding fields work
- [x] Create a PROTOCOL command — verify template picker, parameter inputs, computed payload preview
- [x] Test Processing tab — pre-request script, post-response pattern/script modes
- [x] Test Framing tab — enable override, change strategy, delimiter/script fields
- [x] Test Context tab — link contexts, save new context
- [x] Test Protocol wizard tab — Modbus generator "Use Payload" and AT command selection both switch to basic tab
- [x] Verify `pnpm run type-check` passes clean

Closes #80

🤖 Generated with [Claude Code](https://claude.ai/code)