### PR TITLE
refactor: split ControlPanel into focused sub-components

### DIFF
--- a/src/components/ControlPanel/ConnectionButton.tsx
+++ b/src/components/ControlPanel/ConnectionButton.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { Play, Square } from "lucide-react";
+import { Button } from "../ui/Button";
+import type { TFunction } from "i18next";
+
+interface ConnectionButtonProps {
+  isConnected: boolean;
+  connectionType: "SERIAL" | "NETWORK";
+  onConnect: () => void;
+  onDisconnect: () => void;
+  t: TFunction;
+}
+
+const ConnectionButton: React.FC<ConnectionButtonProps> = ({
+  isConnected,
+  connectionType,
+  onConnect,
+  onDisconnect,
+  t,
+}) => (
+  <div className="flex flex-col gap-1.5 justify-end">
+    <span className="text-[10px] font-bold text-transparent select-none uppercase tracking-wider">
+      Action
+    </span>
+    {!isConnected ? (
+      <Button
+        onClick={onConnect}
+        variant="primary"
+        className="h-9 px-8 shadow-md font-semibold tracking-wide transition-all hover:scale-105 active:scale-95"
+      >
+        <Play className="w-4 h-4 mr-2 fill-current" />{" "}
+        {connectionType === "SERIAL" ? t("cp.open") : t("cp.connect")}
+      </Button>
+    ) : (
+      <Button
+        variant="destructive"
+        onClick={onDisconnect}
+        className="h-9 px-8 shadow-md font-semibold tracking-wide transition-all hover:scale-105 active:scale-95"
+      >
+        <Square className="w-4 h-4 mr-2 fill-current" />{" "}
+        {connectionType === "SERIAL" ? t("cp.close") : t("cp.disconnect")}
+      </Button>
+    )}
+  </div>
+);
+
+export default ConnectionButton;

--- a/src/components/ControlPanel/FramingModal.tsx
+++ b/src/components/ControlPanel/FramingModal.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import { Scissors, X } from "lucide-react";
+import { FramingConfig } from "../../types";
+import { Button } from "../ui/Button";
+import { FramingConfigEditor } from "../shared/FramingConfigEditor";
+
+interface FramingModalProps {
+  isOpen: boolean;
+  config: FramingConfig | undefined;
+  onFramingChange: (updates: Partial<FramingConfig>) => void;
+  onClose: () => void;
+}
+
+const FramingModal: React.FC<FramingModalProps> = ({
+  isOpen,
+  config,
+  onFramingChange,
+  onClose,
+}) => {
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 bg-background/80 backdrop-blur-sm z-60 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl bg-card border border-border rounded-lg shadow-2xl p-6 space-y-4 animate-in fade-in zoom-in-95"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between pb-2 border-b border-border">
+          <h3 className="text-lg font-semibold flex items-center gap-2">
+            <Scissors className="w-4 h-4" /> Framing Strategy
+          </h3>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            className="h-8 w-8"
+          >
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+
+        <FramingConfigEditor config={config} onChange={onFramingChange} />
+
+        <div className="flex justify-end pt-2">
+          <Button onClick={onClose} className="w-full sm:w-auto">
+            Done
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default FramingModal;

--- a/src/components/ControlPanel/ModeSelector.tsx
+++ b/src/components/ControlPanel/ModeSelector.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Cable, Globe } from "lucide-react";
+import { cn } from "../../lib/utils";
+import type { TFunction } from "i18next";
+
+interface ModeSelectorProps {
+  connectionType: "SERIAL" | "NETWORK";
+  isConnected: boolean;
+  onConnectionTypeChange: (type: "SERIAL" | "NETWORK") => void;
+  t: TFunction;
+}
+
+const ModeSelector: React.FC<ModeSelectorProps> = ({
+  connectionType,
+  isConnected,
+  onConnectionTypeChange,
+  t,
+}) => (
+  <div className="flex flex-col gap-1.5">
+    <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+      {t("cp.mode")}
+    </span>
+    <div className="flex items-center bg-muted/30 p-1 rounded-md border border-border h-9">
+      <button
+        onClick={() => onConnectionTypeChange("SERIAL")}
+        disabled={isConnected}
+        className={cn(
+          "px-2 h-full rounded-sm text-xs font-medium flex items-center gap-1.5 transition-all",
+          connectionType === "SERIAL"
+            ? "bg-background shadow-sm text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <Cable className="w-3 h-3" /> Serial
+      </button>
+      <div className="w-px h-3 bg-border/50 mx-1"></div>
+      <button
+        onClick={() => onConnectionTypeChange("NETWORK")}
+        disabled={isConnected}
+        className={cn(
+          "px-2 h-full rounded-sm text-xs font-medium flex items-center gap-1.5 transition-all",
+          connectionType === "NETWORK"
+            ? "bg-background shadow-sm text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <Globe className="w-3 h-3" /> TCP
+      </button>
+    </div>
+  </div>
+);
+
+export default ModeSelector;

--- a/src/components/ControlPanel/NetworkConfigPanel.tsx
+++ b/src/components/ControlPanel/NetworkConfigPanel.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { NetworkConfig } from "../../types";
+import { Input } from "../ui/Input";
+
+interface NetworkConfigPanelProps {
+  networkConfig: NetworkConfig;
+  isConnected: boolean;
+  onNetworkConfigChange: (
+    key: keyof NetworkConfig,
+    value: NetworkConfig[keyof NetworkConfig],
+  ) => void;
+}
+
+const NetworkConfigPanel: React.FC<NetworkConfigPanelProps> = ({
+  networkConfig,
+  isConnected,
+  onNetworkConfigChange,
+}) => (
+  <>
+    <div className="flex flex-col gap-1.5">
+      <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+        Host (WebSocket/IP)
+      </span>
+      <Input
+        value={networkConfig.host}
+        onChange={(e) => onNetworkConfigChange("host", e.target.value)}
+        disabled={isConnected}
+        className="h-9 w-55 text-xs font-mono bg-muted/30 border-border"
+        placeholder="192.168.1.100"
+      />
+    </div>
+    <div className="flex flex-col gap-1.5">
+      <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+        Port
+      </span>
+      <Input
+        type="number"
+        value={networkConfig.port}
+        onChange={(e) =>
+          onNetworkConfigChange("port", parseInt(e.target.value))
+        }
+        disabled={isConnected}
+        className="h-9 w-20 text-xs font-mono bg-muted/30 border-border"
+        placeholder="8080"
+      />
+    </div>
+  </>
+);
+
+export default NetworkConfigPanel;

--- a/src/components/ControlPanel/PresetToolbar.tsx
+++ b/src/components/ControlPanel/PresetToolbar.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Check, RotateCcw, Copy, X, Plus } from "lucide-react";
+import { Button } from "../ui/Button";
+import { cn } from "../../lib/utils";
+import type { TFunction } from "i18next";
+
+interface PresetToolbarProps {
+  loadedPresetId: string | null;
+  activePresetName: string | null | undefined;
+  isPresetDirty: boolean;
+  onUpdate: () => void;
+  onRevert: () => void;
+  onCopy: () => void;
+  onDetach: () => void;
+  onSaveAs: () => void;
+  t: TFunction;
+}
+
+const PresetToolbar: React.FC<PresetToolbarProps> = ({
+  loadedPresetId,
+  activePresetName,
+  isPresetDirty,
+  onUpdate,
+  onRevert,
+  onCopy,
+  onDetach,
+  onSaveAs,
+  t,
+}) => (
+  <>
+    <div className="h-full w-px bg-border/50 mx-2"></div>
+    <div className="flex flex-col gap-1.5">
+      <span className="text-[10px] font-bold text-transparent select-none uppercase tracking-wider">
+        {t("cp.profile")}
+      </span>
+      <div className="flex items-center gap-1.5 bg-muted/30 p-1 rounded-md border border-border h-9">
+        {loadedPresetId ? (
+          <>
+            <div
+              className={cn(
+                "px-2 text-xs font-medium max-w-30 truncate flex items-center gap-1.5",
+                isPresetDirty ? "text-amber-500" : "text-foreground",
+              )}
+            >
+              {activePresetName}
+              {isPresetDirty && (
+                <span
+                  className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse"
+                  title="Unsaved Changes"
+                ></span>
+              )}
+            </div>
+            {isPresetDirty && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-amber-500 hover:text-amber-600 hover:bg-amber-500/10"
+                  onClick={onUpdate}
+                  title="Update Profile"
+                >
+                  <Check className="w-3.5 h-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                  onClick={onRevert}
+                  title="Revert Changes"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" />
+                </Button>
+              </>
+            )}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 text-muted-foreground hover:text-foreground"
+              onClick={onCopy}
+              title="Save As New Preset (Copy)"
+            >
+              <Copy className="w-3.5 h-3.5" />
+            </Button>
+            <div className="w-px h-4 bg-border/50"></div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+              onClick={onDetach}
+              title="Detach (Cancel) Profile"
+            >
+              <X className="w-3.5 h-3.5" />
+            </Button>
+          </>
+        ) : (
+          <div className="px-1 flex items-center gap-2">
+            <span className="text-[10px] text-muted-foreground italic px-1">
+              {t("cp.custom")}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-[10px] gap-1 px-2 border border-dashed border-border"
+              onClick={onSaveAs}
+            >
+              <Plus className="w-3 h-3" /> {t("cp.save_as")}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  </>
+);
+
+export default PresetToolbar;

--- a/src/components/ControlPanel/ProjectActions.tsx
+++ b/src/components/ControlPanel/ProjectActions.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { Upload, Download, Wand2 } from "lucide-react";
+import { Button } from "../ui/Button";
+import { FileInput, FileInputRef } from "../ui/FileInput";
+
+interface ProjectActionsProps {
+  fileInputRef: React.RefObject<FileInputRef | null>;
+  onImport: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onExport: () => void;
+  onOpenAIGenerator: () => void;
+}
+
+const ProjectActions: React.FC<ProjectActionsProps> = ({
+  fileInputRef,
+  onImport,
+  onExport,
+  onOpenAIGenerator,
+}) => (
+  <div className="flex flex-col gap-1.5 justify-end">
+    <span className="text-[10px] font-bold text-transparent select-none uppercase tracking-wider">
+      Project
+    </span>
+    <div className="flex items-center gap-1 bg-muted/30 p-1 rounded-md border border-border">
+      <FileInput ref={fileInputRef} accept=".json" onChange={onImport} />
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => fileInputRef.current?.open()}
+        className="h-7 w-7 rounded-sm hover:bg-background hover:shadow-sm"
+        title="Load Project Backup"
+      >
+        <Upload className="w-3.5 h-3.5" />
+      </Button>
+      <div className="w-px h-4 bg-border/50"></div>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onExport}
+        className="h-7 w-7 rounded-sm hover:bg-background hover:shadow-sm"
+        title="Save Project Backup"
+      >
+        <Download className="w-3.5 h-3.5" />
+      </Button>
+      <div className="w-px h-4 bg-border/50"></div>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onOpenAIGenerator}
+        className="h-7 w-7 rounded-sm hover:bg-background hover:shadow-sm text-purple-500 hover:text-purple-600"
+        title="AI Project Generator (From manual/text)"
+      >
+        <Wand2 className="w-3.5 h-3.5" />
+      </Button>
+    </div>
+  </div>
+);
+
+export default ProjectActions;

--- a/src/components/ControlPanel/SerialConfigPanel.tsx
+++ b/src/components/ControlPanel/SerialConfigPanel.tsx
@@ -1,0 +1,283 @@
+import React from "react";
+import { RefreshCw, Scissors, Link2 } from "lucide-react";
+import { SerialConfig } from "../../types";
+import { Protocol } from "../../lib/protocolTypes";
+import { Button } from "../ui/Button";
+import { Select, SelectDropdown } from "../ui/Select";
+import { DropdownOption } from "../ui/Dropdown";
+import { ISerialPort } from "../../lib/serialService";
+import { cn } from "../../lib/utils";
+import { getSemanticPortName, getPortTooltip } from "../../lib/portUtils";
+import type { TFunction } from "i18next";
+
+interface SerialConfigPanelProps {
+  config: SerialConfig;
+  isConnected: boolean;
+  availablePorts: ISerialPort[];
+  selectedPortIndex: string;
+  onSelectedPortIndexChange: (value: string) => void;
+  onConfigChange: (
+    key: keyof SerialConfig,
+    value: SerialConfig[keyof SerialConfig],
+  ) => void;
+  onRefreshPorts: () => void;
+  onShowFramingModal: () => void;
+  protocols: Protocol[];
+  protocolFramingEnabled: boolean;
+  activeProtocol: Protocol | null;
+  onProtocolFramingToggle: () => void;
+  t: TFunction;
+}
+
+const SerialConfigPanel: React.FC<SerialConfigPanelProps> = ({
+  config,
+  isConnected,
+  availablePorts,
+  selectedPortIndex,
+  onSelectedPortIndexChange,
+  onConfigChange,
+  onRefreshPorts,
+  onShowFramingModal,
+  protocols,
+  protocolFramingEnabled,
+  activeProtocol,
+  onProtocolFramingToggle,
+  t,
+}) => {
+  const strategy = config.framing?.strategy || "NONE";
+
+  return (
+    <>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+          {t("cp.port")}
+        </span>
+        <div className="flex items-center gap-1">
+          <div className="w-50">
+            <Select
+              className="h-9 text-xs font-mono bg-muted/30 border-border focus:border-primary focus:ring-primary/20"
+              value={selectedPortIndex}
+              onChange={(e) => onSelectedPortIndexChange(e.target.value)}
+              disabled={isConnected}
+            >
+              <option value="" disabled>
+                Select a port...
+              </option>
+              <optgroup label="Simulated Devices">
+                <option
+                  value="mock-echo"
+                  className="font-bold text-emerald-600"
+                >
+                  🔌 Virtual Echo Device
+                </option>
+                <option
+                  value="mock-json-stream"
+                  className="font-bold text-blue-600"
+                >
+                  🧩 Virtual JSON Stream (Fragment/Burst)
+                </option>
+                <option
+                  value="mock-timeout-stream"
+                  className="font-bold text-purple-600"
+                >
+                  ⏱️ Virtual Packet Stream (Timeout)
+                </option>
+                <option
+                  value="mock-prefix-stream"
+                  className="font-bold text-amber-600"
+                >
+                  📏 Virtual Prefix Stream (2B LE)
+                </option>
+                <option
+                  value="mock-sine-wave"
+                  className="font-bold text-pink-600"
+                >
+                  📈 Virtual Sine Wave Generator
+                </option>
+              </optgroup>
+              {availablePorts.length > 0 && (
+                <optgroup label="Physical Ports">
+                  {availablePorts.map((port, idx) => {
+                    const rustInfo = port.getRustPortInfo?.();
+                    const semanticName = rustInfo
+                      ? getSemanticPortName(rustInfo)
+                      : `Port ${idx + 1}`;
+                    const tooltip = rustInfo ? getPortTooltip(rustInfo) : "";
+                    return (
+                      <option key={idx} value={idx} title={tooltip}>
+                        {semanticName}
+                      </option>
+                    );
+                  })}
+                </optgroup>
+              )}
+              <option value="new">+ Request New Port...</option>
+            </Select>
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-9 w-9 text-muted-foreground hover:text-foreground bg-muted/30 border-border"
+            onClick={onRefreshPorts}
+            title="Refresh Ports"
+          >
+            <RefreshCw className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+          {t("cp.baud")}
+        </span>
+        <div className="w-25">
+          <SelectDropdown
+            options={[
+              9600, 19200, 38400, 57600, 74880, 115200, 230400, 460800, 921600,
+            ].map(
+              (r): DropdownOption<number> => ({
+                value: r,
+                label: r.toString(),
+              }),
+            )}
+            value={config.baudRate}
+            onChange={(value) => onConfigChange("baudRate", value)}
+            disabled={isConnected}
+            size="sm"
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+          Data Bits
+        </span>
+        <div className="w-24">
+          <SelectDropdown
+            options={
+              [
+                { value: "Eight", label: "8-bit" },
+                { value: "Seven", label: "7-bit" },
+              ] as DropdownOption<SerialConfig["dataBits"]>[]
+            }
+            value={config.dataBits}
+            onChange={(value) => onConfigChange("dataBits", value)}
+            disabled={isConnected}
+            size="sm"
+            menuMinWidth={120}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+          Parity
+        </span>
+        <div className="w-24">
+          <SelectDropdown
+            options={
+              [
+                { value: "None", label: "None" },
+                { value: "Even", label: "Even" },
+                { value: "Odd", label: "Odd" },
+              ] as DropdownOption<SerialConfig["parity"]>[]
+            }
+            value={config.parity}
+            onChange={(value) => onConfigChange("parity", value)}
+            disabled={isConnected}
+            size="sm"
+            menuMinWidth={120}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+          Stop Bits
+        </span>
+        <div className="w-24">
+          <SelectDropdown
+            options={
+              [
+                { value: "One", label: "1-bit" },
+                { value: "Two", label: "2-bit" },
+              ] as DropdownOption<SerialConfig["stopBits"]>[]
+            }
+            value={config.stopBits}
+            onChange={(value) => onConfigChange("stopBits", value)}
+            disabled={isConnected}
+            size="sm"
+            menuMinWidth={120}
+          />
+        </div>
+      </div>
+
+      {/* Framing Strategy Section */}
+      <div className="flex flex-col gap-1.5 relative">
+        <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider pl-1">
+          {t("cp.framing")}
+        </span>
+        <div className="flex items-center gap-1">
+          {/* Protocol Framing Toggle */}
+          {protocols.length > 0 && (
+            <Button
+              variant="outline"
+              className={cn(
+                "h-9 px-2 text-xs gap-1.5 border-border bg-muted/30",
+                protocolFramingEnabled &&
+                  activeProtocol &&
+                  "border-emerald-500/50 text-emerald-600 bg-emerald-500/5",
+              )}
+              onClick={onProtocolFramingToggle}
+              title={
+                protocolFramingEnabled && activeProtocol
+                  ? `Using framing from: ${activeProtocol.name}`
+                  : "Enable protocol-defined framing"
+              }
+            >
+              <Link2
+                className={cn(
+                  "w-3.5 h-3.5",
+                  protocolFramingEnabled && "text-emerald-500",
+                )}
+              />
+              {protocolFramingEnabled && activeProtocol
+                ? activeProtocol.name.length > 8
+                  ? activeProtocol.name.slice(0, 8) + "\u2026"
+                  : activeProtocol.name
+                : "Proto"}
+            </Button>
+          )}
+          {/* Custom Framing Button */}
+          <Button
+            variant="outline"
+            className={cn(
+              "h-9 px-3 text-xs gap-2 border-border bg-muted/30",
+              !protocolFramingEnabled &&
+                strategy !== "NONE" &&
+                "border-primary/50 text-primary bg-primary/5",
+            )}
+            onClick={onShowFramingModal}
+            disabled={protocolFramingEnabled}
+            title={
+              protocolFramingEnabled
+                ? "Disable protocol framing to use custom framing"
+                : "Configure custom framing strategy"
+            }
+          >
+            <Scissors className="w-3.5 h-3.5" />
+            {protocolFramingEnabled
+              ? "Custom"
+              : strategy === "NONE"
+                ? "None"
+                : strategy === "TIMEOUT"
+                  ? "Timeout"
+                  : strategy === "PREFIX_LENGTH"
+                    ? "Prefix"
+                    : strategy === "SCRIPT"
+                      ? "Script"
+                      : "Delim"}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SerialConfigPanel;


### PR DESCRIPTION
## Summary
- Split `ControlPanel.tsx` (981 lines) into 7 focused presentational sub-components under `src/components/ControlPanel/`
- Container keeps all state, effects, and handlers; sub-components receive props only
- Follows the same pattern used in PR #144 (CommandFormModal split)

### Sub-components extracted
| Component | Responsibility |
|---|---|
| `ModeSelector` | Serial/TCP toggle buttons |
| `SerialConfigPanel` | Port selector, baud, databits, parity, stopbits, framing |
| `NetworkConfigPanel` | Host + port inputs |
| `PresetToolbar` | Preset name, dirty indicator, update/revert/copy/detach/save-as |
| `ProjectActions` | Import/export/AI generator buttons |
| `ConnectionButton` | Connect/disconnect button |
| `FramingModal` | Framing strategy portal modal |

### Result
- `ControlPanel.tsx`: 981 → 533 lines (container with state + composition)
- Zero new lint warnings or type errors
- No functional changes — pure refactor

## Test plan
- [x] `pnpm run type-check` — zero errors
- [x] `pnpm run build` — successful production build
- [x] `pnpm run lint` — 0 errors (72 pre-existing warnings unchanged)
- [ ] Manual: verify mode selector, serial config dropdowns, preset toolbar, connect button all render and function

🤖 Generated with [Claude Code](https://claude.ai/code)