### PR TITLE
refactor: split sidebar into focused sub-components

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,41 +1,15 @@
 import React, { useState, useMemo, useEffect } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { SavedCommand, SerialSequence, SerialPreset } from "../types";
-import {
-  Play,
-  Trash2,
-  Plus,
-  Folder,
-  Terminal,
-  Link2,
-  FileClock,
-  Settings,
-  Coins,
-  Pencil,
-  PanelLeftClose,
-  PanelLeft,
-  Layers,
-  ExternalLink,
-  Search,
-  ChevronDown,
-  ChevronRight,
-} from "lucide-react";
+import { PanelLeftClose, PanelLeft } from "lucide-react";
 import { IconButton } from "./ui/IconButton";
-import { Badge } from "./ui/Badge";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "./ui/Accordion";
-import { cn, generateId } from "../lib/utils";
+import { generateId } from "../lib/utils";
 import SequenceFormModal from "./SequenceFormModal";
 import CommandFormModal from "./CommandFormModal";
 import SimpleInputModal from "./SimpleInputModal";
 import ConfirmationModal from "./ConfirmationModal";
 import DeviceFormModal from "./DeviceFormModal";
 import { useStore } from "../lib/store";
-import { EmptyState } from "./ui/EmptyState";
 import { useTranslation } from "react-i18next";
 import {
   useSidebarUIState,
@@ -49,7 +23,14 @@ import {
   useAITokenUsage,
   useActiveSessionBasicInfo,
 } from "../lib/selectors";
-// Note: DeviceList is no longer used inline - Devices now links to /devices page
+
+import SearchBar from "./Sidebar/SearchBar";
+import CollapsedSidebar from "./Sidebar/CollapsedSidebar";
+import SidebarFooter from "./Sidebar/SidebarFooter";
+import DeviceSection from "./Sidebar/DeviceSection";
+import ProtocolSection from "./Sidebar/ProtocolSection";
+import CommandSection from "./Sidebar/CommandSection";
+import SequenceSection from "./Sidebar/SequenceSection";
 
 interface Props {
   onSendCommand: (cmd: SavedCommand) => void;
@@ -353,7 +334,7 @@ const Sidebar: React.FC<Props> = ({ onSendCommand, onRunSequence }) => {
       className="flex flex-col bg-bg-surface border-r border-border-default h-full relative z-10 shadow-xl shrink-0 transition-[width] ease-out duration-75"
       style={{ width: leftSidebarCollapsed ? 56 : sidebarWidth }}
     >
-      {/* 48px Header - Section 8.3 */}
+      {/* 48px Header */}
       <div className="h-12 flex items-center justify-between px-4 border-b border-border-default shrink-0">
         {!leftSidebarCollapsed && (
           <span className="text-heading-sm font-semibold text-text-primary uppercase tracking-wider">
@@ -380,633 +361,77 @@ const Sidebar: React.FC<Props> = ({ onSendCommand, onRunSequence }) => {
 
       {/* Collapsed State - Icon Rail */}
       {leftSidebarCollapsed && (
-        <div className="flex-1 flex flex-col items-center py-3 gap-2">
-          <IconButton
-            variant="ghost"
-            size="md"
-            onClick={() => setLeftSidebarCollapsed(false)}
-            aria-label="Library"
-            title="Library"
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <Terminal className="w-5 h-5" />
-          </IconButton>
-          <div className="flex-1" />
-          <IconButton
-            variant="ghost"
-            size="md"
-            onClick={() => setShowSystemLogs(true)}
-            aria-label={t("sidebar.logs")}
-            title={t("sidebar.logs")}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <FileClock className="w-5 h-5" />
-          </IconButton>
-          <IconButton
-            variant="ghost"
-            size="md"
-            onClick={() => setShowAppSettings(true)}
-            aria-label={t("sidebar.settings")}
-            title={t("sidebar.settings")}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <Settings className="w-5 h-5" />
-          </IconButton>
-          {aiTokenUsage.total > 0 && (
-            <div
-              className="flex flex-col items-center gap-0.5 mt-2"
-              title={`Token Usage: ${aiTokenUsage.total}`}
-            >
-              <Coins className="w-3 h-3 text-amber-500" />
-              <span className="text-[9px] font-mono text-muted-foreground">
-                {(aiTokenUsage.total / 1000).toFixed(1)}k
-              </span>
-            </div>
-          )}
-        </div>
+        <CollapsedSidebar
+          onExpand={() => setLeftSidebarCollapsed(false)}
+          onShowSystemLogs={() => setShowSystemLogs(true)}
+          onShowAppSettings={() => setShowAppSettings(true)}
+          aiTokenTotal={aiTokenUsage.total}
+          t={t}
+        />
       )}
 
       {/* Expanded Content */}
       {!leftSidebarCollapsed && (
         <>
-          {/* 40px Search Input - 12px margin - Section 8.3 */}
-          <div className="px-3 py-3">
-            <div className="relative h-10">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
-              <input
-                type="text"
-                placeholder="Search..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full h-full pl-9 pr-3 rounded-radius-sm border border-border-default bg-bg-muted text-body-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent-primary/50 focus:border-accent-primary"
-              />
-            </div>
-          </div>
+          <SearchBar
+            searchQuery={searchQuery}
+            onSearchQueryChange={setSearchQuery}
+          />
 
           {/* Scrollable Content */}
           <div className="flex-1 overflow-y-auto custom-scrollbar">
             <div className="flex flex-col">
-              {/* DEVICES Section - 32px header */}
-              <div
-                className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
-                onClick={() => toggleSidebarSection("devices")}
-              >
-                <div className="flex items-center gap-2">
-                  {sidebarSectionsCollapsed.devices ? (
-                    <ChevronRight className="w-4 h-4 text-text-muted" />
-                  ) : (
-                    <ChevronDown className="w-4 h-4 text-text-muted" />
-                  )}
-                  <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
-                    Devices
-                  </span>
-                  <Badge
-                    variant="secondary"
-                    className="text-[10px] h-4 px-1.5 py-0"
-                  >
-                    {devices.length}
-                  </Badge>
-                </div>
-                <div
-                  className="flex items-center gap-1"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Link
-                    to="/devices"
-                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                    aria-label="Open Device Library"
-                    title="Open Device Library"
-                  >
-                    <ExternalLink className="w-4 h-4" />
-                  </Link>
-                  <IconButton
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => {
-                      useStore.getState().setEditingDevice(null);
-                      useStore.getState().setShowDeviceModal(true);
-                    }}
-                    aria-label="Add Device"
-                    title="Add Device"
-                  >
-                    <Plus className="w-3.5 h-3.5" />
-                  </IconButton>
-                </div>
-              </div>
-              {!sidebarSectionsCollapsed.devices && (
-                <div className="px-3 py-2 flex flex-col gap-1">
-                  {/* All Devices option */}
-                  <button
-                    onClick={() =>
-                      useStore.getState().setSelectedDeviceId(null)
-                    }
-                    className={cn(
-                      "flex items-center gap-2 px-2 py-1.5 rounded-radius-sm text-body-sm transition-colors text-left",
-                      selectedDeviceId === null
-                        ? "bg-accent-primary/10 text-accent-primary font-medium"
-                        : "hover:bg-bg-hover text-text-muted",
-                    )}
-                    title="Show commands and sequences from all devices"
-                  >
-                    <Layers className="w-4 h-4" />
-                    <span>All Devices</span>
-                  </button>
+              <DeviceSection
+                devices={devices}
+                selectedDeviceId={selectedDeviceId}
+                isCollapsed={sidebarSectionsCollapsed.devices}
+                onToggleCollapse={() => toggleSidebarSection("devices")}
+              />
 
-                  {devices.map((device) => (
-                    <div
-                      key={device.id}
-                      role="button"
-                      tabIndex={0}
-                      onClick={() =>
-                        useStore.getState().setSelectedDeviceId(device.id)
-                      }
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          useStore.getState().setSelectedDeviceId(device.id);
-                        }
-                      }}
-                      className={cn(
-                        "group flex items-center justify-between px-2 py-1.5 rounded-radius-sm text-body-sm transition-colors cursor-pointer",
-                        selectedDeviceId === device.id
-                          ? "bg-accent-primary/10 text-accent-primary border-l-2 border-accent-primary"
-                          : "hover:bg-bg-hover",
-                      )}
-                    >
-                      <span className="truncate">{device.name}</span>
-                      <IconButton
-                        variant="ghost"
-                        size="xs"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          navigate(`/devices/${device.id}/edit`);
-                        }}
-                        className="opacity-0 group-hover:opacity-100 transition-opacity"
-                        aria-label="Edit Device"
-                        title="Edit Device"
-                      >
-                        <Pencil className="w-3 h-3" />
-                      </IconButton>
-                    </div>
-                  ))}
+              <ProtocolSection
+                protocols={protocols}
+                isCollapsed={sidebarSectionsCollapsed.protocols}
+                onToggleCollapse={() => toggleSidebarSection("protocols")}
+                onCreateProtocol={handleCreateProtocol}
+              />
 
-                  {devices.length === 0 && (
-                    <EmptyState
-                      variant="devices"
-                      className="py-4"
-                      onAction={() =>
-                        useStore.getState().setShowDeviceModal(true)
-                      }
-                    />
-                  )}
-                </div>
-              )}
+              <CommandSection
+                filteredCommands={filteredCommands}
+                groupedCommands={groupedCommands}
+                selectedDeviceId={selectedDeviceId}
+                selectedCommandId={selectedCommandId}
+                collapsedGroups={collapsedGroups}
+                isCollapsed={sidebarSectionsCollapsed.commands}
+                onToggleCollapse={() => toggleSidebarSection("commands")}
+                onToggleGroup={toggleGroup}
+                onCommandClick={handleCommandClick}
+                onSendCommand={onSendCommand}
+                onCreateCommand={handleCreateNewCommand}
+                onDeleteCommand={deleteCommand}
+                onDeleteCommands={deleteCommands}
+                onRequestConfirmation={setConfirmation}
+                t={t}
+              />
 
-              {/* PROTOCOLS Section - 32px header */}
-              <div
-                className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
-                onClick={() => toggleSidebarSection("protocols")}
-              >
-                <div className="flex items-center gap-2">
-                  {sidebarSectionsCollapsed.protocols ? (
-                    <ChevronRight className="w-4 h-4 text-text-muted" />
-                  ) : (
-                    <ChevronDown className="w-4 h-4 text-text-muted" />
-                  )}
-                  <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
-                    Protocols
-                  </span>
-                  <Badge
-                    variant="secondary"
-                    className="text-[10px] h-4 px-1.5 py-0"
-                  >
-                    {protocols.length}
-                  </Badge>
-                </div>
-                <div
-                  className="flex items-center gap-1"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Link
-                    to="/protocols"
-                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                    aria-label="Open Protocol Library"
-                    title="Open Protocol Library"
-                  >
-                    <ExternalLink className="w-4 h-4" />
-                  </Link>
-                  <IconButton
-                    variant="ghost"
-                    size="xs"
-                    onClick={handleCreateProtocol}
-                    aria-label="Create Protocol"
-                    title="Create Protocol"
-                  >
-                    <Plus className="w-3.5 h-3.5" />
-                  </IconButton>
-                </div>
-              </div>
-              {!sidebarSectionsCollapsed.protocols && (
-                <div className="px-3 py-2 flex flex-col gap-1">
-                  {protocols.map((protocol) => (
-                    <Link
-                      key={protocol.id}
-                      to={`/protocols/${protocol.id}/edit`}
-                      className="flex items-center gap-2 px-2 py-1.5 rounded-radius-sm text-body-sm hover:bg-bg-hover transition-colors"
-                    >
-                      <Layers className="w-4 h-4 text-text-muted" />
-                      <span className="truncate">{protocol.name}</span>
-                    </Link>
-                  ))}
-                  {protocols.length === 0 && (
-                    <EmptyState
-                      variant="protocols"
-                      className="py-4"
-                      onAction={handleCreateProtocol}
-                    />
-                  )}
-                </div>
-              )}
-
-              {/* COMMANDS Section - 32px header */}
-              <div
-                className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
-                onClick={() => toggleSidebarSection("commands")}
-              >
-                <div className="flex items-center gap-2">
-                  {sidebarSectionsCollapsed.commands ? (
-                    <ChevronRight className="w-4 h-4 text-text-muted" />
-                  ) : (
-                    <ChevronDown className="w-4 h-4 text-text-muted" />
-                  )}
-                  <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
-                    {t("sidebar.commands")}
-                  </span>
-                  <Badge
-                    variant="secondary"
-                    className="text-[10px] h-4 px-1.5 py-0"
-                  >
-                    {filteredCommands.length}
-                  </Badge>
-                </div>
-                <div
-                  className="flex items-center gap-1"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Link
-                    to="/commands"
-                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                    aria-label="Open Command Library"
-                    title="Open Command Library"
-                  >
-                    <ExternalLink className="w-4 h-4" />
-                  </Link>
-                  <IconButton
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => handleCreateNewCommand()}
-                    aria-label={t("sidebar.new_command")}
-                    title={t("sidebar.new_command")}
-                  >
-                    <Plus className="w-3.5 h-3.5" />
-                  </IconButton>
-                </div>
-              </div>
-              {!sidebarSectionsCollapsed.commands && (
-                <div className="px-3 py-2">
-                  {filteredCommands.length === 0 ? (
-                    <EmptyState
-                      variant="commands"
-                      title={
-                        selectedDeviceId
-                          ? "No commands for this device"
-                          : undefined
-                      }
-                      className="py-4"
-                      onAction={() => handleCreateNewCommand()}
-                    />
-                  ) : (
-                    <Accordion className="w-full space-y-1">
-                      {groupedCommands.map((group) => {
-                        if (group.items.length === 0) return null;
-                        const isUngrouped = group.name === "Ungrouped";
-                        const isExpanded = !collapsedGroups.has(group.name);
-
-                        return (
-                          <AccordionItem
-                            key={group.name}
-                            className="border-none"
-                          >
-                            {!isUngrouped && (
-                              <div className="flex items-center justify-between group/header pr-1 hover:bg-bg-hover rounded-radius-sm">
-                                <AccordionTrigger
-                                  isOpen={isExpanded}
-                                  onClick={() => toggleGroup(group.name)}
-                                  className="py-1.5 px-2 hover:no-underline hover:text-accent-primary"
-                                >
-                                  <div className="flex items-center gap-2">
-                                    <Folder className="w-3.5 h-3.5 fill-current opacity-50" />
-                                    <span className="text-body-xs font-semibold">
-                                      {group.name}
-                                    </span>
-                                  </div>
-                                </AccordionTrigger>
-                                <div className="flex gap-0.5 opacity-0 group-hover/header:opacity-100 transition-opacity mr-1">
-                                  <IconButton
-                                    variant="primary"
-                                    size="xs"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      handleCreateNewCommand(group.name);
-                                    }}
-                                    aria-label="Add command to group"
-                                    title="Add command to group"
-                                  >
-                                    <Plus className="w-3 h-3" />
-                                  </IconButton>
-                                  <IconButton
-                                    variant="destructive"
-                                    size="xs"
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      setConfirmation({
-                                        title: t("modal.delete"),
-                                        message: `Delete "${group.name}" and all its commands?`,
-                                        action: () =>
-                                          deleteCommands(
-                                            group.items.map((i) => i.id),
-                                          ),
-                                      });
-                                    }}
-                                    aria-label="Delete group"
-                                    title="Delete group"
-                                  >
-                                    <Trash2 className="w-3 h-3" />
-                                  </IconButton>
-                                </div>
-                              </div>
-                            )}
-
-                            <AccordionContent
-                              isOpen={isUngrouped ? true : isExpanded}
-                              className={cn(
-                                !isUngrouped &&
-                                  "pl-2 ml-2 border-l border-border-default/40",
-                              )}
-                            >
-                              <div className="flex flex-col gap-1.5 pt-1">
-                                {group.items.map((cmd) => {
-                                  const isSelected =
-                                    selectedCommandId === cmd.id;
-                                  return (
-                                    <div
-                                      key={cmd.id}
-                                      onClick={() => handleCommandClick(cmd)}
-                                      className={cn(
-                                        "group flex flex-col gap-1 p-2 rounded-radius-md transition-all relative cursor-pointer border",
-                                        isSelected
-                                          ? "bg-accent-primary/10 border-accent-primary shadow-sm ring-1 ring-accent-primary/20"
-                                          : "bg-bg-muted/30 border-border-default/50 hover:bg-bg-hover hover:border-border-default hover:shadow-sm",
-                                      )}
-                                    >
-                                      <div className="flex items-center justify-between">
-                                        <div className="flex items-center gap-1.5 overflow-hidden">
-                                          {cmd.source === "PROTOCOL" && (
-                                            <Layers className="w-3 h-3 text-blue-500 shrink-0" />
-                                          )}
-                                          <span
-                                            className={cn(
-                                              "font-medium text-body-sm truncate",
-                                              isSelected &&
-                                                "text-accent-primary",
-                                            )}
-                                          >
-                                            {cmd.name}
-                                          </span>
-                                          {cmd.usedBy?.length ? (
-                                            <span className="text-[9px] opacity-50">
-                                              <Link2 className="w-2.5 h-2.5" />
-                                            </span>
-                                          ) : null}
-                                        </div>
-                                        <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-                                          <IconButton
-                                            variant="primary"
-                                            size="xs"
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              onSendCommand(cmd);
-                                            }}
-                                            aria-label="Send"
-                                            title="Send"
-                                          >
-                                            <Play className="w-3 h-3 fill-current" />
-                                          </IconButton>
-                                          <IconButton
-                                            variant="ghost"
-                                            size="xs"
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              navigate(
-                                                `/commands/${cmd.id}/edit`,
-                                              );
-                                            }}
-                                            aria-label="Open Full Editor"
-                                            title="Open Full Editor"
-                                          >
-                                            <ExternalLink className="w-3 h-3" />
-                                          </IconButton>
-                                          <IconButton
-                                            variant="destructive"
-                                            size="xs"
-                                            onClick={(e) => {
-                                              e.stopPropagation();
-                                              setConfirmation({
-                                                title: t("modal.delete"),
-                                                message: `Delete command "${cmd.name}"?`,
-                                                action: () =>
-                                                  deleteCommand(cmd.id),
-                                              });
-                                            }}
-                                            aria-label="Delete"
-                                            title="Delete"
-                                          >
-                                            <Trash2 className="w-3 h-3" />
-                                          </IconButton>
-                                        </div>
-                                      </div>
-                                      <div className="flex items-center gap-2">
-                                        <Badge
-                                          variant="outline"
-                                          className="text-[8px] h-3.5 px-1 py-0 border-border-default/60 text-text-muted uppercase"
-                                        >
-                                          {cmd.mode}
-                                        </Badge>
-                                        <code className="text-[10px] text-text-muted truncate font-mono flex-1 opacity-70">
-                                          {(cmd.payload || "")
-                                            .replace(/\r/g, "CR")
-                                            .replace(/\n/g, "LF")}
-                                        </code>
-                                      </div>
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            </AccordionContent>
-                          </AccordionItem>
-                        );
-                      })}
-                    </Accordion>
-                  )}
-                </div>
-              )}
-
-              {/* SEQUENCES Section - 32px header */}
-              <div
-                className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
-                onClick={() => toggleSidebarSection("sequences")}
-              >
-                <div className="flex items-center gap-2">
-                  {sidebarSectionsCollapsed.sequences ? (
-                    <ChevronRight className="w-4 h-4 text-text-muted" />
-                  ) : (
-                    <ChevronDown className="w-4 h-4 text-text-muted" />
-                  )}
-                  <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
-                    {t("sidebar.sequences")}
-                  </span>
-                  <Badge
-                    variant="secondary"
-                    className="text-[10px] h-4 px-1.5 py-0"
-                  >
-                    {filteredSequences.length}
-                  </Badge>
-                </div>
-                <div
-                  className="flex items-center gap-1"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Link
-                    to="/sequences"
-                    className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
-                    aria-label="Open Sequence Library"
-                    title="Open Sequence Library"
-                  >
-                    <ExternalLink className="w-4 h-4" />
-                  </Link>
-                  <IconButton
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => handleOpenSeqModal()}
-                    aria-label="Create Sequence"
-                    title="Create Sequence"
-                  >
-                    <Plus className="w-3.5 h-3.5" />
-                  </IconButton>
-                </div>
-              </div>
-              {!sidebarSectionsCollapsed.sequences && (
-                <div className="px-3 py-2">
-                  {filteredSequences.length === 0 ? (
-                    <EmptyState
-                      variant="sequences"
-                      title={
-                        selectedDeviceId
-                          ? "No sequences for this device"
-                          : undefined
-                      }
-                      className="py-4"
-                      onAction={() => handleOpenSeqModal()}
-                    />
-                  ) : (
-                    <div className="flex flex-col gap-1.5">
-                      {filteredSequences.map((seq) => (
-                        <div
-                          key={seq.id}
-                          className="group flex flex-col gap-1 p-2 rounded-radius-sm hover:bg-bg-hover transition-all"
-                        >
-                          <div className="flex items-center justify-between">
-                            <span className="font-medium text-body-sm truncate">
-                              {seq.name}
-                            </span>
-                            <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                              <IconButton
-                                variant="primary"
-                                size="xs"
-                                onClick={() => onRunSequence(seq)}
-                                aria-label="Run Sequence"
-                                title="Run Sequence"
-                              >
-                                <Play className="w-3 h-3 fill-current" />
-                              </IconButton>
-                              <IconButton
-                                variant="ghost"
-                                size="xs"
-                                onClick={() => handleOpenSeqModal(seq)}
-                                aria-label="Quick Edit"
-                                title="Quick Edit"
-                              >
-                                <Pencil className="w-3 h-3" />
-                              </IconButton>
-                              <IconButton
-                                variant="ghost"
-                                size="xs"
-                                onClick={() =>
-                                  navigate(`/sequences/${seq.id}/edit`)
-                                }
-                                aria-label="Open Full Editor"
-                                title="Open Full Editor"
-                              >
-                                <ExternalLink className="w-3 h-3" />
-                              </IconButton>
-                            </div>
-                          </div>
-                          <div className="text-body-xs text-text-muted">
-                            {seq.steps.length} step
-                            {seq.steps.length !== 1 ? "s" : ""}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
+              <SequenceSection
+                filteredSequences={filteredSequences}
+                selectedDeviceId={selectedDeviceId}
+                isCollapsed={sidebarSectionsCollapsed.sequences}
+                onToggleCollapse={() => toggleSidebarSection("sequences")}
+                onRunSequence={onRunSequence}
+                onEditSequence={(seq) => handleOpenSeqModal(seq)}
+                onCreateSequence={() => handleOpenSeqModal()}
+                t={t}
+              />
             </div>
           </div>
 
-          {/* Bottom Section - Settings & Info */}
-          <div className="px-3 py-3 border-t border-border-default bg-bg-muted/20 shrink-0 space-y-2">
-            <IconButton
-              variant="ghost"
-              size="md"
-              onClick={() => setShowSystemLogs(true)}
-              aria-label={t("sidebar.logs")}
-              title={t("sidebar.logs")}
-              className="w-full justify-start gap-2 text-text-secondary hover:text-foreground"
-            >
-              <FileClock className="w-4 h-4" />
-              <span className="text-sm">{t("sidebar.logs")}</span>
-            </IconButton>
-            <IconButton
-              variant="ghost"
-              size="md"
-              onClick={() => setShowAppSettings(true)}
-              aria-label={t("sidebar.settings")}
-              title={t("sidebar.settings")}
-              className="w-full justify-start gap-2 text-text-secondary hover:text-foreground"
-            >
-              <Settings className="w-4 h-4" />
-              <span className="text-sm">{t("sidebar.settings")}</span>
-            </IconButton>
-            {aiTokenUsage.total > 0 && (
-              <div className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground">
-                <Coins className="w-3.5 h-3.5 text-amber-500" />
-                <span className="font-mono">
-                  {(aiTokenUsage.total / 1000).toFixed(1)}k tokens
-                </span>
-              </div>
-            )}
-          </div>
+          <SidebarFooter
+            onShowSystemLogs={() => setShowSystemLogs(true)}
+            onShowAppSettings={() => setShowAppSettings(true)}
+            aiTokenTotal={aiTokenUsage.total}
+            t={t}
+          />
         </>
       )}
 

--- a/src/components/Sidebar/CollapsedSidebar.tsx
+++ b/src/components/Sidebar/CollapsedSidebar.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Terminal, FileClock, Settings, Coins } from "lucide-react";
+import { IconButton } from "../ui/IconButton";
+import type { TFunction } from "i18next";
+
+interface CollapsedSidebarProps {
+  onExpand: () => void;
+  onShowSystemLogs: () => void;
+  onShowAppSettings: () => void;
+  aiTokenTotal: number;
+  t: TFunction;
+}
+
+const CollapsedSidebar: React.FC<CollapsedSidebarProps> = ({
+  onExpand,
+  onShowSystemLogs,
+  onShowAppSettings,
+  aiTokenTotal,
+  t,
+}) => (
+  <div className="flex-1 flex flex-col items-center py-3 gap-2">
+    <IconButton
+      variant="ghost"
+      size="md"
+      onClick={onExpand}
+      aria-label="Library"
+      title="Library"
+      className="text-muted-foreground hover:text-foreground"
+    >
+      <Terminal className="w-5 h-5" />
+    </IconButton>
+    <div className="flex-1" />
+    <IconButton
+      variant="ghost"
+      size="md"
+      onClick={onShowSystemLogs}
+      aria-label={t("sidebar.logs")}
+      title={t("sidebar.logs")}
+      className="text-muted-foreground hover:text-foreground"
+    >
+      <FileClock className="w-5 h-5" />
+    </IconButton>
+    <IconButton
+      variant="ghost"
+      size="md"
+      onClick={onShowAppSettings}
+      aria-label={t("sidebar.settings")}
+      title={t("sidebar.settings")}
+      className="text-muted-foreground hover:text-foreground"
+    >
+      <Settings className="w-5 h-5" />
+    </IconButton>
+    {aiTokenTotal > 0 && (
+      <div
+        className="flex flex-col items-center gap-0.5 mt-2"
+        title={`Token Usage: ${aiTokenTotal}`}
+      >
+        <Coins className="w-3 h-3 text-amber-500" />
+        <span className="text-[9px] font-mono text-muted-foreground">
+          {(aiTokenTotal / 1000).toFixed(1)}k
+        </span>
+      </div>
+    )}
+  </div>
+);
+
+export default CollapsedSidebar;

--- a/src/components/Sidebar/CommandSection.tsx
+++ b/src/components/Sidebar/CommandSection.tsx
@@ -1,0 +1,299 @@
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { SavedCommand } from "../../types";
+import {
+  Play,
+  Trash2,
+  Plus,
+  Folder,
+  Link2,
+  Layers,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { IconButton } from "../ui/IconButton";
+import { Badge } from "../ui/Badge";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../ui/Accordion";
+import { cn } from "../../lib/utils";
+import { EmptyState } from "../ui/EmptyState";
+import type { TFunction } from "i18next";
+
+interface CommandGroup {
+  name: string;
+  items: SavedCommand[];
+}
+
+interface ConfirmationRequest {
+  title: string;
+  message: string;
+  action: () => void;
+}
+
+interface CommandSectionProps {
+  filteredCommands: SavedCommand[];
+  groupedCommands: CommandGroup[];
+  selectedDeviceId: string | null;
+  selectedCommandId: string | null;
+  collapsedGroups: Set<string>;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onToggleGroup: (groupName: string) => void;
+  onCommandClick: (cmd: SavedCommand) => void;
+  onSendCommand: (cmd: SavedCommand) => void;
+  onCreateCommand: (groupName?: string) => void;
+  onDeleteCommand: (id: string) => void;
+  onDeleteCommands: (ids: string[]) => void;
+  onRequestConfirmation: (confirmation: ConfirmationRequest) => void;
+  t: TFunction;
+}
+
+const CommandSection: React.FC<CommandSectionProps> = ({
+  filteredCommands,
+  groupedCommands,
+  selectedDeviceId,
+  selectedCommandId,
+  collapsedGroups,
+  isCollapsed,
+  onToggleCollapse,
+  onToggleGroup,
+  onCommandClick,
+  onSendCommand,
+  onCreateCommand,
+  onDeleteCommand,
+  onDeleteCommands,
+  onRequestConfirmation,
+  t,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <div
+        className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
+        onClick={onToggleCollapse}
+      >
+        <div className="flex items-center gap-2">
+          {isCollapsed ? (
+            <ChevronRight className="w-4 h-4 text-text-muted" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-text-muted" />
+          )}
+          <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
+            {t("sidebar.commands")}
+          </span>
+          <Badge variant="secondary" className="text-[10px] h-4 px-1.5 py-0">
+            {filteredCommands.length}
+          </Badge>
+        </div>
+        <div
+          className="flex items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Link
+            to="/commands"
+            className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Open Command Library"
+            title="Open Command Library"
+          >
+            <ExternalLink className="w-4 h-4" />
+          </Link>
+          <IconButton
+            variant="ghost"
+            size="xs"
+            onClick={() => onCreateCommand()}
+            aria-label={t("sidebar.new_command")}
+            title={t("sidebar.new_command")}
+          >
+            <Plus className="w-3.5 h-3.5" />
+          </IconButton>
+        </div>
+      </div>
+      {!isCollapsed && (
+        <div className="px-3 py-2">
+          {filteredCommands.length === 0 ? (
+            <EmptyState
+              variant="commands"
+              title={
+                selectedDeviceId ? "No commands for this device" : undefined
+              }
+              className="py-4"
+              onAction={() => onCreateCommand()}
+            />
+          ) : (
+            <Accordion className="w-full space-y-1">
+              {groupedCommands.map((group) => {
+                if (group.items.length === 0) return null;
+                const isUngrouped = group.name === "Ungrouped";
+                const isExpanded = !collapsedGroups.has(group.name);
+
+                return (
+                  <AccordionItem key={group.name} className="border-none">
+                    {!isUngrouped && (
+                      <div className="flex items-center justify-between group/header pr-1 hover:bg-bg-hover rounded-radius-sm">
+                        <AccordionTrigger
+                          isOpen={isExpanded}
+                          onClick={() => onToggleGroup(group.name)}
+                          className="py-1.5 px-2 hover:no-underline hover:text-accent-primary"
+                        >
+                          <div className="flex items-center gap-2">
+                            <Folder className="w-3.5 h-3.5 fill-current opacity-50" />
+                            <span className="text-body-xs font-semibold">
+                              {group.name}
+                            </span>
+                          </div>
+                        </AccordionTrigger>
+                        <div className="flex gap-0.5 opacity-0 group-hover/header:opacity-100 transition-opacity mr-1">
+                          <IconButton
+                            variant="primary"
+                            size="xs"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onCreateCommand(group.name);
+                            }}
+                            aria-label="Add command to group"
+                            title="Add command to group"
+                          >
+                            <Plus className="w-3 h-3" />
+                          </IconButton>
+                          <IconButton
+                            variant="destructive"
+                            size="xs"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onRequestConfirmation({
+                                title: t("modal.delete"),
+                                message: `Delete "${group.name}" and all its commands?`,
+                                action: () =>
+                                  onDeleteCommands(
+                                    group.items.map((i) => i.id),
+                                  ),
+                              });
+                            }}
+                            aria-label="Delete group"
+                            title="Delete group"
+                          >
+                            <Trash2 className="w-3 h-3" />
+                          </IconButton>
+                        </div>
+                      </div>
+                    )}
+
+                    <AccordionContent
+                      isOpen={isUngrouped ? true : isExpanded}
+                      className={cn(
+                        !isUngrouped &&
+                          "pl-2 ml-2 border-l border-border-default/40",
+                      )}
+                    >
+                      <div className="flex flex-col gap-1.5 pt-1">
+                        {group.items.map((cmd) => {
+                          const isSelected = selectedCommandId === cmd.id;
+                          return (
+                            <div
+                              key={cmd.id}
+                              onClick={() => onCommandClick(cmd)}
+                              className={cn(
+                                "group flex flex-col gap-1 p-2 rounded-radius-md transition-all relative cursor-pointer border",
+                                isSelected
+                                  ? "bg-accent-primary/10 border-accent-primary shadow-sm ring-1 ring-accent-primary/20"
+                                  : "bg-bg-muted/30 border-border-default/50 hover:bg-bg-hover hover:border-border-default hover:shadow-sm",
+                              )}
+                            >
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-1.5 overflow-hidden">
+                                  {cmd.source === "PROTOCOL" && (
+                                    <Layers className="w-3 h-3 text-blue-500 shrink-0" />
+                                  )}
+                                  <span
+                                    className={cn(
+                                      "font-medium text-body-sm truncate",
+                                      isSelected && "text-accent-primary",
+                                    )}
+                                  >
+                                    {cmd.name}
+                                  </span>
+                                  {cmd.usedBy?.length ? (
+                                    <span className="text-[9px] opacity-50">
+                                      <Link2 className="w-2.5 h-2.5" />
+                                    </span>
+                                  ) : null}
+                                </div>
+                                <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                                  <IconButton
+                                    variant="primary"
+                                    size="xs"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onSendCommand(cmd);
+                                    }}
+                                    aria-label="Send"
+                                    title="Send"
+                                  >
+                                    <Play className="w-3 h-3 fill-current" />
+                                  </IconButton>
+                                  <IconButton
+                                    variant="ghost"
+                                    size="xs"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      navigate(`/commands/${cmd.id}/edit`);
+                                    }}
+                                    aria-label="Open Full Editor"
+                                    title="Open Full Editor"
+                                  >
+                                    <ExternalLink className="w-3 h-3" />
+                                  </IconButton>
+                                  <IconButton
+                                    variant="destructive"
+                                    size="xs"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onRequestConfirmation({
+                                        title: t("modal.delete"),
+                                        message: `Delete command "${cmd.name}"?`,
+                                        action: () => onDeleteCommand(cmd.id),
+                                      });
+                                    }}
+                                    aria-label="Delete"
+                                    title="Delete"
+                                  >
+                                    <Trash2 className="w-3 h-3" />
+                                  </IconButton>
+                                </div>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <Badge
+                                  variant="outline"
+                                  className="text-[8px] h-3.5 px-1 py-0 border-border-default/60 text-text-muted uppercase"
+                                >
+                                  {cmd.mode}
+                                </Badge>
+                                <code className="text-[10px] text-text-muted truncate font-mono flex-1 opacity-70">
+                                  {(cmd.payload || "")
+                                    .replace(/\r/g, "CR")
+                                    .replace(/\n/g, "LF")}
+                                </code>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </AccordionContent>
+                  </AccordionItem>
+                );
+              })}
+            </Accordion>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default CommandSection;

--- a/src/components/Sidebar/DeviceSection.tsx
+++ b/src/components/Sidebar/DeviceSection.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import {
+  Plus,
+  Layers,
+  Pencil,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { Device } from "../../types";
+import { IconButton } from "../ui/IconButton";
+import { Badge } from "../ui/Badge";
+import { EmptyState } from "../ui/EmptyState";
+import { cn } from "../../lib/utils";
+import { useStore } from "../../lib/store";
+
+interface DeviceSectionProps {
+  devices: Device[];
+  selectedDeviceId: string | null;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+}
+
+const DeviceSection: React.FC<DeviceSectionProps> = ({
+  devices,
+  selectedDeviceId,
+  isCollapsed,
+  onToggleCollapse,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <div
+        className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
+        onClick={onToggleCollapse}
+      >
+        <div className="flex items-center gap-2">
+          {isCollapsed ? (
+            <ChevronRight className="w-4 h-4 text-text-muted" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-text-muted" />
+          )}
+          <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
+            Devices
+          </span>
+          <Badge variant="secondary" className="text-[10px] h-4 px-1.5 py-0">
+            {devices.length}
+          </Badge>
+        </div>
+        <div
+          className="flex items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Link
+            to="/devices"
+            className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Open Device Library"
+            title="Open Device Library"
+          >
+            <ExternalLink className="w-4 h-4" />
+          </Link>
+          <IconButton
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              useStore.getState().setEditingDevice(null);
+              useStore.getState().setShowDeviceModal(true);
+            }}
+            aria-label="Add Device"
+            title="Add Device"
+          >
+            <Plus className="w-3.5 h-3.5" />
+          </IconButton>
+        </div>
+      </div>
+      {!isCollapsed && (
+        <div className="px-3 py-2 flex flex-col gap-1">
+          <button
+            onClick={() => useStore.getState().setSelectedDeviceId(null)}
+            className={cn(
+              "flex items-center gap-2 px-2 py-1.5 rounded-radius-sm text-body-sm transition-colors text-left",
+              selectedDeviceId === null
+                ? "bg-accent-primary/10 text-accent-primary font-medium"
+                : "hover:bg-bg-hover text-text-muted",
+            )}
+            title="Show commands and sequences from all devices"
+          >
+            <Layers className="w-4 h-4" />
+            <span>All Devices</span>
+          </button>
+
+          {devices.map((device) => (
+            <div
+              key={device.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => useStore.getState().setSelectedDeviceId(device.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  useStore.getState().setSelectedDeviceId(device.id);
+                }
+              }}
+              className={cn(
+                "group flex items-center justify-between px-2 py-1.5 rounded-radius-sm text-body-sm transition-colors cursor-pointer",
+                selectedDeviceId === device.id
+                  ? "bg-accent-primary/10 text-accent-primary border-l-2 border-accent-primary"
+                  : "hover:bg-bg-hover",
+              )}
+            >
+              <span className="truncate">{device.name}</span>
+              <IconButton
+                variant="ghost"
+                size="xs"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigate(`/devices/${device.id}/edit`);
+                }}
+                className="opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label="Edit Device"
+                title="Edit Device"
+              >
+                <Pencil className="w-3 h-3" />
+              </IconButton>
+            </div>
+          ))}
+
+          {devices.length === 0 && (
+            <EmptyState
+              variant="devices"
+              className="py-4"
+              onAction={() => useStore.getState().setShowDeviceModal(true)}
+            />
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default DeviceSection;

--- a/src/components/Sidebar/ProtocolSection.tsx
+++ b/src/components/Sidebar/ProtocolSection.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import {
+  Plus,
+  Layers,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { Protocol } from "../../lib/protocolTypes";
+import { IconButton } from "../ui/IconButton";
+import { Badge } from "../ui/Badge";
+import { EmptyState } from "../ui/EmptyState";
+
+interface ProtocolSectionProps {
+  protocols: Protocol[];
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onCreateProtocol: () => void;
+}
+
+const ProtocolSection: React.FC<ProtocolSectionProps> = ({
+  protocols,
+  isCollapsed,
+  onToggleCollapse,
+  onCreateProtocol,
+}) => (
+  <>
+    <div
+      className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
+      onClick={onToggleCollapse}
+    >
+      <div className="flex items-center gap-2">
+        {isCollapsed ? (
+          <ChevronRight className="w-4 h-4 text-text-muted" />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-text-muted" />
+        )}
+        <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
+          Protocols
+        </span>
+        <Badge variant="secondary" className="text-[10px] h-4 px-1.5 py-0">
+          {protocols.length}
+        </Badge>
+      </div>
+      <div
+        className="flex items-center gap-1"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Link
+          to="/protocols"
+          className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Open Protocol Library"
+          title="Open Protocol Library"
+        >
+          <ExternalLink className="w-4 h-4" />
+        </Link>
+        <IconButton
+          variant="ghost"
+          size="xs"
+          onClick={onCreateProtocol}
+          aria-label="Create Protocol"
+          title="Create Protocol"
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </IconButton>
+      </div>
+    </div>
+    {!isCollapsed && (
+      <div className="px-3 py-2 flex flex-col gap-1">
+        {protocols.map((protocol) => (
+          <Link
+            key={protocol.id}
+            to={`/protocols/${protocol.id}/edit`}
+            className="flex items-center gap-2 px-2 py-1.5 rounded-radius-sm text-body-sm hover:bg-bg-hover transition-colors"
+          >
+            <Layers className="w-4 h-4 text-text-muted" />
+            <span className="truncate">{protocol.name}</span>
+          </Link>
+        ))}
+        {protocols.length === 0 && (
+          <EmptyState
+            variant="protocols"
+            className="py-4"
+            onAction={onCreateProtocol}
+          />
+        )}
+      </div>
+    )}
+  </>
+);
+
+export default ProtocolSection;

--- a/src/components/Sidebar/SearchBar.tsx
+++ b/src/components/Sidebar/SearchBar.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Search } from "lucide-react";
+
+interface SearchBarProps {
+  searchQuery: string;
+  onSearchQueryChange: (query: string) => void;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({
+  searchQuery,
+  onSearchQueryChange,
+}) => (
+  <div className="px-3 py-3">
+    <div className="relative h-10">
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+      <input
+        type="text"
+        placeholder="Search..."
+        value={searchQuery}
+        onChange={(e) => onSearchQueryChange(e.target.value)}
+        className="w-full h-full pl-9 pr-3 rounded-radius-sm border border-border-default bg-bg-muted text-body-sm text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-accent-primary/50 focus:border-accent-primary"
+      />
+    </div>
+  </div>
+);
+
+export default SearchBar;

--- a/src/components/Sidebar/SequenceSection.tsx
+++ b/src/components/Sidebar/SequenceSection.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { SerialSequence } from "../../types";
+import {
+  Play,
+  Plus,
+  Pencil,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import { IconButton } from "../ui/IconButton";
+import { Badge } from "../ui/Badge";
+import { EmptyState } from "../ui/EmptyState";
+import type { TFunction } from "i18next";
+
+interface SequenceSectionProps {
+  filteredSequences: SerialSequence[];
+  selectedDeviceId: string | null;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  onRunSequence: (seq: SerialSequence) => void;
+  onEditSequence: (seq: SerialSequence) => void;
+  onCreateSequence: () => void;
+  t: TFunction;
+}
+
+const SequenceSection: React.FC<SequenceSectionProps> = ({
+  filteredSequences,
+  selectedDeviceId,
+  isCollapsed,
+  onToggleCollapse,
+  onRunSequence,
+  onEditSequence,
+  onCreateSequence,
+  t,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <div
+        className="h-8 flex items-center justify-between px-3 cursor-pointer hover:bg-bg-hover transition-colors border-b border-border-default"
+        onClick={onToggleCollapse}
+      >
+        <div className="flex items-center gap-2">
+          {isCollapsed ? (
+            <ChevronRight className="w-4 h-4 text-text-muted" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-text-muted" />
+          )}
+          <span className="text-label-sm font-semibold text-text-secondary uppercase tracking-wider">
+            {t("sidebar.sequences")}
+          </span>
+          <Badge variant="secondary" className="text-[10px] h-4 px-1.5 py-0">
+            {filteredSequences.length}
+          </Badge>
+        </div>
+        <div
+          className="flex items-center gap-1"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Link
+            to="/sequences"
+            className="inline-flex items-center justify-center rounded-radius-sm transition-colors h-6 w-6 p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Open Sequence Library"
+            title="Open Sequence Library"
+          >
+            <ExternalLink className="w-4 h-4" />
+          </Link>
+          <IconButton
+            variant="ghost"
+            size="xs"
+            onClick={onCreateSequence}
+            aria-label="Create Sequence"
+            title="Create Sequence"
+          >
+            <Plus className="w-3.5 h-3.5" />
+          </IconButton>
+        </div>
+      </div>
+      {!isCollapsed && (
+        <div className="px-3 py-2">
+          {filteredSequences.length === 0 ? (
+            <EmptyState
+              variant="sequences"
+              title={
+                selectedDeviceId ? "No sequences for this device" : undefined
+              }
+              className="py-4"
+              onAction={onCreateSequence}
+            />
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {filteredSequences.map((seq) => (
+                <div
+                  key={seq.id}
+                  className="group flex flex-col gap-1 p-2 rounded-radius-sm hover:bg-bg-hover transition-all"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-body-sm truncate">
+                      {seq.name}
+                    </span>
+                    <div className="flex gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <IconButton
+                        variant="primary"
+                        size="xs"
+                        onClick={() => onRunSequence(seq)}
+                        aria-label="Run Sequence"
+                        title="Run Sequence"
+                      >
+                        <Play className="w-3 h-3 fill-current" />
+                      </IconButton>
+                      <IconButton
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => onEditSequence(seq)}
+                        aria-label="Quick Edit"
+                        title="Quick Edit"
+                      >
+                        <Pencil className="w-3 h-3" />
+                      </IconButton>
+                      <IconButton
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => navigate(`/sequences/${seq.id}/edit`)}
+                        aria-label="Open Full Editor"
+                        title="Open Full Editor"
+                      >
+                        <ExternalLink className="w-3 h-3" />
+                      </IconButton>
+                    </div>
+                  </div>
+                  <div className="text-body-xs text-text-muted">
+                    {seq.steps.length} step
+                    {seq.steps.length !== 1 ? "s" : ""}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default SequenceSection;

--- a/src/components/Sidebar/SidebarFooter.tsx
+++ b/src/components/Sidebar/SidebarFooter.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { FileClock, Settings, Coins } from "lucide-react";
+import { IconButton } from "../ui/IconButton";
+import type { TFunction } from "i18next";
+
+interface SidebarFooterProps {
+  onShowSystemLogs: () => void;
+  onShowAppSettings: () => void;
+  aiTokenTotal: number;
+  t: TFunction;
+}
+
+const SidebarFooter: React.FC<SidebarFooterProps> = ({
+  onShowSystemLogs,
+  onShowAppSettings,
+  aiTokenTotal,
+  t,
+}) => (
+  <div className="px-3 py-3 border-t border-border-default bg-bg-muted/20 shrink-0 space-y-2">
+    <IconButton
+      variant="ghost"
+      size="md"
+      onClick={onShowSystemLogs}
+      aria-label={t("sidebar.logs")}
+      title={t("sidebar.logs")}
+      className="w-full justify-start gap-2 text-text-secondary hover:text-foreground"
+    >
+      <FileClock className="w-4 h-4" />
+      <span className="text-sm">{t("sidebar.logs")}</span>
+    </IconButton>
+    <IconButton
+      variant="ghost"
+      size="md"
+      onClick={onShowAppSettings}
+      aria-label={t("sidebar.settings")}
+      title={t("sidebar.settings")}
+      className="w-full justify-start gap-2 text-text-secondary hover:text-foreground"
+    >
+      <Settings className="w-4 h-4" />
+      <span className="text-sm">{t("sidebar.settings")}</span>
+    </IconButton>
+    {aiTokenTotal > 0 && (
+      <div className="flex items-center gap-2 px-2 py-1 text-xs text-muted-foreground">
+        <Coins className="w-3.5 h-3.5 text-amber-500" />
+        <span className="font-mono">
+          {(aiTokenTotal / 1000).toFixed(1)}k tokens
+        </span>
+      </div>
+    )}
+  </div>
+);
+
+export default SidebarFooter;


### PR DESCRIPTION
## Summary
- Extract 7 presentational sub-components from `Sidebar.tsx` (1094 → 518 lines, 53% reduction)
- New components in `src/components/Sidebar/`: `SearchBar`, `CollapsedSidebar`, `SidebarFooter`, `DeviceSection`, `ProtocolSection`, `CommandSection`, `SequenceSection`
- Container keeps all state, handlers, effects, and modals; sub-components receive state/callbacks via props
- Also fixed a bug in `CommandSection` where `onDeleteCommand` and `onDeleteCommands` were declared in the interface but not destructured from props

Closes #82

## Test plan
- [x] `pnpm run type-check` — 0 errors
- [x] `pnpm run build` — successful production build
- [x] `pnpm run lint` — 0 errors (72 pre-existing warnings)
- [x] Playwright: sidebar header, search, device/protocol/command/sequence sections all render
- [x] Playwright: collapse/expand toggle renders CollapsedSidebar with icon rail
- [x] Playwright: footer shows System Logs and Settings buttons

🤖 Generated with [Claude Code](https://claude.ai/code)