### PR TITLE
feat: add ts-pattern for exhaustive pattern matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-virtuoso": "^4.18.1",
     "recharts": "2.15.0",
     "tailwind-merge": "^2.6.0",
+    "ts-pattern": "^5.9.0",
     "zod": "3.25.76",
     "zod-validation-error": "^5.0.0",
     "zustand": "^5.0.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
+      ts-pattern:
+        specifier: ^5.9.0
+        version: 5.9.0
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -3352,6 +3355,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-pattern@5.9.0:
+    resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -7172,6 +7178,8 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-pattern@5.9.0: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
## Summary
- Adds `ts-pattern` (v5.9.0) for compile-time exhaustive pattern matching
- Refactors switch statements in 4 core library files to use `match().with().exhaustive()`
- Eliminates silent `default` fallthrough by requiring all enum cases to be handled
- Catches a real gap: `DataType` includes `STRING` and `BYTES` which were silently falling to defaults

### Files changed
| File | Switches converted | Key benefit |
|------|-------------------|-------------|
| `parameterUtils.ts` | 4 (syntax, substitute, transform, mode) | Exhaustive mode matching |
| `dataUtils.ts` | 3 (checksum, line ending, encoding) | All algorithms covered |
| `messageParser.ts` | 2 (decode, size) | DataType exhaustiveness |
| `messageBuilder.ts` | 2 (encode, size) | Mirrors parser safety |

## Test plan
- [x] `pnpm run type-check` — passes clean
- [x] `pnpm run lint` — 0 errors (warnings are pre-existing)
- [x] `pnpm build` — production build succeeds
- [x] Playwright browser verification — app loads and renders correctly

Closes #106

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)