### PR TITLE
feat: replace custom toast system with sonner

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-router-dom": "^7.13.0",
     "react-virtuoso": "^4.18.1",
     "recharts": "2.15.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.0",
     "ts-pattern": "^5.9.0",
     "zod": "3.25.76",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       recharts:
         specifier: 2.15.0
         version: 2.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -3189,6 +3192,12 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -7006,6 +7015,11 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,19 +1,19 @@
-import React, { useEffect } from "react";
-import { CheckCircle, XCircle, Info, AlertTriangle, X } from "lucide-react";
-import { cn } from "../../lib/utils";
+import { Toaster as SonnerToaster } from "sonner";
+import { useStore } from "../../lib/store";
 
 /**
- * Toast Component
+ * Toast System
+ *
+ * Built on sonner for accessible, animated toast notifications.
  *
  * Design System Specifications (FIGMA-DESIGN.md 6.5):
  * - Position: Bottom right, 24px margin
  * - Max Width: 400px
- * - Padding: 16px
- * - Border Radius: radius.md
- * - Shadow: shadow.lg
  * - Variants: success (green), warning (amber), error (red), info (blue)
- * - Left border: 4px in variant color
- * - Animation: Slide in from right, 300ms
+ * - Animation: Slide in from right
+ *
+ * Usage: Call `addToast(type, title, message)` from the zustand store.
+ * Sonner handles rendering, dismissal, and stacking automatically.
  */
 
 export interface ToastMessage {
@@ -28,113 +28,24 @@ export interface ToastMessage {
   duration?: number;
 }
 
-interface ToastContainerProps {
-  toasts: ToastMessage[];
-  removeToast: (id: string) => void;
-}
+const ToastContainer: React.FC = () => {
+  const themeMode = useStore((state) => state.themeMode);
 
-const variantStyles = {
-  success: {
-    bg: "bg-green-50 dark:bg-green-900/30",
-    border: "border-l-status-success",
-    icon: CheckCircle,
-    iconColor: "text-status-success",
-  },
-  error: {
-    bg: "bg-red-50 dark:bg-red-900/30",
-    border: "border-l-status-error",
-    icon: XCircle,
-    iconColor: "text-status-error",
-  },
-  warning: {
-    bg: "bg-amber-50 dark:bg-amber-900/30",
-    border: "border-l-status-warning",
-    icon: AlertTriangle,
-    iconColor: "text-status-warning",
-  },
-  info: {
-    bg: "bg-blue-50 dark:bg-blue-900/30",
-    border: "border-l-status-info",
-    icon: Info,
-    iconColor: "text-status-info",
-  },
-};
-
-const ToastContainer: React.FC<ToastContainerProps> = ({
-  toasts,
-  removeToast,
-}) => {
   return (
-    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2 pointer-events-none">
-      {toasts.map((toast) => (
-        <ToastItem
-          key={toast.id}
-          toast={toast}
-          onRemove={() => removeToast(toast.id)}
-        />
-      ))}
-    </div>
+    <SonnerToaster
+      position="bottom-right"
+      richColors
+      theme={themeMode === "system" ? "system" : themeMode}
+      toastOptions={{
+        style: {
+          maxWidth: "400px",
+        },
+      }}
+    />
   );
 };
 
-interface ToastItemProps {
-  toast: ToastMessage;
-  onRemove: () => void;
-}
+ToastContainer.displayName = "ToastContainer";
 
-const ToastItem: React.FC<ToastItemProps> = ({ toast, onRemove }) => {
-  const { type, title, message, action, duration = 4000 } = toast;
-  const styles = variantStyles[type];
-  const Icon = styles.icon;
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      onRemove();
-    }, duration);
-    return () => clearTimeout(timer);
-  }, [onRemove, duration]);
-
-  return (
-    <div
-      className={cn(
-        "pointer-events-auto w-full max-w-[400px] p-4 rounded-radius-md shadow-lg",
-        "border-l-4 border border-border-default",
-        styles.bg,
-        styles.border,
-        "animate-in slide-in-from-right-full duration-300",
-      )}
-    >
-      <div className="flex items-start gap-3">
-        {/* Icon */}
-        <Icon
-          className={cn("w-5 h-5 flex-shrink-0 mt-0.5", styles.iconColor)}
-        />
-
-        {/* Content */}
-        <div className="flex-1 min-w-0">
-          <h4 className="text-sm font-semibold text-text-primary">{title}</h4>
-          <p className="text-xs text-text-secondary mt-1">{message}</p>
-          {action && (
-            <button
-              onClick={action.onClick}
-              className="text-xs font-medium text-accent-primary hover:underline mt-2"
-            >
-              {action.label}
-            </button>
-          )}
-        </div>
-
-        {/* Close button */}
-        <button
-          onClick={onRemove}
-          className="flex-shrink-0 p-1 rounded-radius-sm text-text-muted hover:text-text-primary hover:bg-bg-hover transition-colors"
-        >
-          <X className="w-4 h-4" />
-        </button>
-      </div>
-    </div>
-  );
-};
-
+export { ToastContainer };
 export default ToastContainer;
-export { ToastContainer, ToastItem };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -51,7 +51,7 @@ export type { TabItem } from "./TabBar";
 export { TabPanel } from "./TabPanel";
 export { TabRailButton, tabRailButtonVariants } from "./TabRailButton";
 export { Textarea, textareaVariants } from "./Textarea";
-export { ToastContainer, ToastItem } from "./Toast";
+export { ToastContainer } from "./Toast";
 export type { ToastMessage } from "./Toast";
 export { Toggle } from "./Toggle";
 export { Tooltip } from "./Tooltip";

--- a/src/lib/selectors.ts
+++ b/src/lib/selectors.ts
@@ -115,7 +115,6 @@ export const useStoreActions = () =>
 
       // Toasts
       addToast: state.addToast,
-      removeToast: state.removeToast,
 
       // Other
       setPresets: state.setPresets,
@@ -165,11 +164,6 @@ export const useModals = () =>
       showAppSettings: state.showAppSettings,
     })),
   );
-
-/**
- * Get toasts
- */
-export const useToasts = () => useStore((state) => state.toasts);
 
 // --- Project Data Selectors ---
 

--- a/src/lib/slices/uiSlice.ts
+++ b/src/lib/slices/uiSlice.ts
@@ -1,4 +1,5 @@
 import { StateCreator } from "zustand";
+import { toast } from "sonner";
 import { generateId } from "../utils";
 import { ToastMessage } from "../../components/ui";
 import {
@@ -32,9 +33,8 @@ export interface UISliceState {
   // AI Settings
   geminiApiKey: string;
 
-  // System Logs & Toasts
+  // System Logs
   systemLogs: SystemLogEntry[];
-  toasts: ToastMessage[];
 
   // Modal & Visibility State
   editingCommand: Partial<SavedCommand> | null;
@@ -88,8 +88,6 @@ export interface UISliceActions {
       duration?: number;
     },
   ) => void;
-  removeToast: (id: string) => void;
-
   // Modals & Visibility State
   setEditingCommand: (cmd: Partial<SavedCommand> | null) => void;
   setIsCommandModalOpen: (open: boolean) => void;
@@ -164,25 +162,14 @@ export const createUISlice: StateCreator<UISlice> = (set, get) => ({
     })),
   clearSystemLogs: () => set({ systemLogs: [] }),
 
-  toasts: [],
   addToast: (type, title, message, options) => {
-    const id = generateId();
-    set((state) => ({
-      toasts: [
-        ...state.toasts,
-        {
-          id,
-          type,
-          title,
-          message,
-          action: options?.action,
-          duration: options?.duration,
-        },
-      ],
-    }));
+    const toastFn = toast[type] ?? toast;
+    toastFn(title, {
+      description: message,
+      duration: options?.duration ?? 4000,
+      action: options?.action,
+    });
   },
-  removeToast: (id) =>
-    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
 
   editingCommand: null,
   isCommandModalOpen: false,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -22,8 +22,6 @@ import {
 } from "react-router-dom";
 import { ArrowLeft, Home, AlertTriangle, RefreshCw } from "lucide-react";
 import { Button, ToastContainer } from "../components/ui";
-import { useStore } from "../lib/store";
-import { useShallow } from "zustand/react/shallow";
 
 // Lazy load pages for better performance
 const MainWorkspace = React.lazy(() => import("../pages/MainWorkspace"));
@@ -91,19 +89,12 @@ const RouteErrorBoundary: React.FC = () => {
 
 // Root layout with navigation
 const RootLayout: React.FC = () => {
-  const { toasts, removeToast } = useStore(
-    useShallow((state) => ({
-      toasts: state.toasts,
-      removeToast: state.removeToast,
-    })),
-  );
-
   return (
     <div className="h-screen w-full bg-background text-foreground overflow-hidden">
       <React.Suspense fallback={<PageLoader />}>
         <Outlet />
       </React.Suspense>
-      <ToastContainer toasts={toasts} removeToast={removeToast} />
+      <ToastContainer />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Replace custom toast notification system with [sonner](https://sonner.emilkowal.dev/) for accessible, animated toast notifications
- Simplify zustand store by removing `toasts` array state and `removeToast` action
- `addToast(type, title, message)` API preserved — all 22 call sites work unchanged

## Changes
- **`src/components/ui/Toast.tsx`**: Replace 141-line custom implementation with sonner `Toaster` wrapper (51 lines)
- **`src/lib/slices/uiSlice.ts`**: `addToast` now calls `toast.success/error/info/warning()` from sonner; removed `toasts` state and `removeToast` action
- **`src/routes/index.tsx`**: Simplified `RootLayout` — `ToastContainer` no longer needs props
- **`src/lib/selectors.ts`**: Removed `removeToast` selector and `useToasts` hook (no longer needed)
- **`src/components/ui/index.ts`**: Removed `ToastItem` export

## Benefits
- Auto-stacking, swipe-to-dismiss, accessible announcements out of the box
- Rich colors with theme-aware rendering (light/dark/system)
- No manual state management — sonner handles its own lifecycle
- Reduced store complexity (removed toasts array from zustand)
- Net reduction: -102 lines

## Test plan
- [x] TypeScript type-check passes
- [x] ESLint: 0 errors
- [x] Vite build passes
- [x] Playwright verification: created preset, confirmed sonner toast appeared with correct title ("Saved") and description

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)