### PR TITLE
ci: add cargo-llvm-cov for rust code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,16 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Run Rust tests
-        run: cd src-tauri && cargo test
-        env:
-          RUSTC_WRAPPER: sccache
+      - name: Run Rust tests with coverage
+        run: cd src-tauri && cargo llvm-cov --lcov --output-path ../lcov-rust.info
+
+      - name: Upload Rust coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./lcov-rust.info
+          flags: rust
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Install `cargo-llvm-cov` via `taiki-e/install-action` in the `test-rust` CI job
- Replace `cargo test` with `cargo llvm-cov --lcov` for source-based LLVM coverage
- Upload Rust coverage to Codecov with `rust` flag for separate tracking
- Remove sccache from `test-rust` job (conflicts with cargo-llvm-cov's own RUSTC_WRAPPER)

Closes #125

## Test plan

- [ ] Verify `test-rust` job passes with cargo-llvm-cov
- [ ] Verify `lcov-rust.info` is generated and uploaded to Codecov
- [ ] Confirm sccache remains active in `build.yml` (unaffected)

🤖 Generated with [Claude Code](https://claude.ai/code)