### PR TITLE
ci: add codecov configuration for coverage tracking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,9 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage/coverage-final.json
+          flags: frontend
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-rust:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,33 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  behavior: default
+  require_changes: true
+
+flags:
+  frontend:
+    paths:
+      - src/
+    carryforward: true
+  rust:
+    paths:
+      - src-tauri/src/
+    carryforward: true
+
+ignore:
+  - "src/lib/tauri/bindings.ts"
+  - "src/tests/**"
+  - "**/*.test.*"
+  - "**/*.spec.*"


### PR DESCRIPTION
## Summary

- Add `codecov.yml` configuration file with:
  - Project coverage: auto target with 1% regression threshold
  - Patch coverage: 80% target for new code
  - Condensed PR comment layout (only shown when coverage changes)
  - Separate `frontend` and `rust` flags for independent tracking
  - Ignore patterns for test files and generated `bindings.ts`
  - Carryforward flags so partial uploads don't drop coverage
- Add `CODECOV_TOKEN` and `frontend` flag to existing frontend coverage upload step

Closes #122

## Test plan

- [ ] Verify CI passes (workflow YAML is valid)
- [ ] Verify Codecov picks up `codecov.yml` config after merge
- [ ] Confirm PR comments appear on subsequent PRs with coverage changes

🤖 Generated with [Claude Code](https://claude.ai/code)