### PR TITLE
feat: add vite-bundle-analyzer for bundle optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:e2e:ui": "playwright test --ui",
     "explore": "playwright-cli open http://localhost:14200 --headed",
     "explore:help": "playwright-cli --help",
-    "prepare": "husky"
+    "prepare": "husky",
+    "analyze": "vite-bundle-analyzer"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "6.2.1",
@@ -97,6 +98,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.54.0",
     "vite": "^6.4.1",
+    "vite-bundle-analyzer": "^1.3.6",
     "vitest": "^4.0.18"
   },
   "packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite-bundle-analyzer:
+        specifier: ^1.3.6
+        version: 1.3.6
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@22.19.7)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(yaml@2.8.2)
@@ -4161,6 +4164,10 @@ packages:
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  vite-bundle-analyzer@1.3.6:
+    resolution: {integrity: sha512-elFXkF9oGy4CJEeOdP1DSEHRDKWfmaEDfT9/GuF4jmyfmUF6nC//iN+ythqMEVvrtchOEHGKLumZwnu1NjoI0w==}
+    hasBin: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -8792,6 +8799,8 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  vite-bundle-analyzer@1.3.6: {}
 
   vite@6.4.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
     dependencies:


### PR DESCRIPTION
## Summary

Add `vite-bundle-analyzer` for visualizing bundle composition and identifying optimization opportunities.

Usage:
```bash
pnpm run analyze
```

This opens an interactive treemap showing:
- Bundle size breakdown by dependency
- Large dependencies (CodeMirror, Recharts, react-markdown, etc.)
- Code-splitting opportunities

Closes #108

## Test plan

- [ ] Verify `pnpm run analyze` opens the bundle visualization
- [ ] Confirm no build regressions

🤖 Generated with [Claude Code](https://claude.ai/code)