### PR TITLE
refactor: phase 4 architecture - extract hooks and clean up deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "ansi-to-react": "6.1.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eventemitter3": "^5.0.4",
     "cmdk": "^1.1.1",
     "i18next": "23.10.0",
     "immer": "^11.1.3",
@@ -64,7 +63,6 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.0",
     "ts-pattern": "^5.9.0",
-    "typed-emitter": "^2.1.0",
     "zod": "3.25.76",
     "zod-validation-error": "^5.0.0",
     "zustand": "^5.0.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      eventemitter3:
-        specifier: ^5.0.4
-        version: 5.0.4
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -134,9 +131,6 @@ importers:
       ts-pattern:
         specifier: ^5.9.0
         version: 5.9.0
-      typed-emitter:
-        specifier: ^2.1.0
-        version: 2.1.0
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -3897,9 +3891,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
-
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
@@ -4218,9 +4209,6 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
-
-  typed-emitter@2.1.0:
-    resolution: {integrity: sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==}
 
   typescript-eslint@8.54.0:
     resolution: {integrity: sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==}
@@ -8611,11 +8599,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  rxjs@7.8.2:
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
@@ -8962,10 +8945,6 @@ snapshots:
       is-typed-array: 1.1.15
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
-
-  typed-emitter@2.1.0:
-    optionalDependencies:
-      rxjs: 7.8.2
 
   typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3):
     dependencies:

--- a/src/hooks/usePresetOperations.ts
+++ b/src/hooks/usePresetOperations.ts
@@ -1,0 +1,128 @@
+import { useEffect, useMemo } from "react";
+import { SerialPreset, DashboardWidget } from "../types";
+import { generateId } from "../lib/utils";
+import { useStore } from "../lib/store";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Encapsulates preset management logic extracted from ControlPanel (#81).
+ *
+ * Handles: dirty detection, save/update/revert/copy/detach operations.
+ */
+export function usePresetOperations() {
+  const { t } = useTranslation();
+  const {
+    sessions,
+    activeSessionId,
+    presets,
+    loadedPresetId,
+    setLoadedPresetId,
+    setPresets,
+    setConfig,
+    setNetworkConfig,
+    setConnectionType,
+    applyPresetLayout,
+    addToast,
+  } = useStore();
+
+  const activeSession = sessions[activeSessionId];
+  const { config, networkConfig, connectionType, widgets } = activeSession;
+
+  const activePresetName = loadedPresetId
+    ? (presets.find((p) => p.id === loadedPresetId)?.name ?? null)
+    : null;
+
+  const isPresetDirty = useMemo(() => {
+    if (!loadedPresetId) return false;
+    const preset = presets.find((p) => p.id === loadedPresetId);
+    if (!preset) return false;
+    if (preset.type !== connectionType) return true;
+    if (preset.type === "SERIAL")
+      return JSON.stringify(preset.config) !== JSON.stringify(config);
+    else
+      return JSON.stringify(preset.network) !== JSON.stringify(networkConfig);
+  }, [loadedPresetId, presets, config, networkConfig, connectionType]);
+
+  // When loadedPresetId changes, apply dashboard layout if exists
+  useEffect(() => {
+    if (loadedPresetId) {
+      applyPresetLayout(activeSessionId, loadedPresetId);
+    }
+  }, [loadedPresetId, activeSessionId, applyPresetLayout]);
+
+  const extractDashboardConfig = (): DashboardWidget[] => {
+    return [...widgets];
+  };
+
+  const updateLoadedPreset = () => {
+    if (!loadedPresetId) return;
+    const preset = presets.find((p) => p.id === loadedPresetId);
+    if (!preset) return;
+
+    const updatedPreset: SerialPreset = {
+      ...preset,
+      type: connectionType,
+      config: connectionType === "SERIAL" ? config : preset.config,
+      network: connectionType === "NETWORK" ? networkConfig : preset.network,
+      widgets: extractDashboardConfig(),
+    };
+
+    setPresets((prev) =>
+      prev.map((p) => (p.id === loadedPresetId ? updatedPreset : p)),
+    );
+    addToast(
+      "success",
+      t("toast.success"),
+      `Saved config & dashboard to "${preset.name}".`,
+    );
+  };
+
+  const revertLoadedPreset = () => {
+    if (!loadedPresetId) return;
+    const p = presets.find((x) => x.id === loadedPresetId);
+    if (p) {
+      if (p.type === "NETWORK") {
+        setConnectionType("NETWORK");
+        if (p.network) setNetworkConfig(p.network);
+      } else {
+        setConnectionType("SERIAL");
+        setConfig(p.config);
+      }
+      applyPresetLayout(activeSessionId, loadedPresetId);
+      addToast("info", "Reverted", "Settings restored from profile.");
+    }
+  };
+
+  const saveNewPreset = (name: string) => {
+    const newPreset: SerialPreset = {
+      id: generateId(),
+      name,
+      type: connectionType,
+      config: { ...config },
+      network: connectionType === "NETWORK" ? { ...networkConfig } : undefined,
+      widgets: extractDashboardConfig(),
+    };
+    setPresets((prev) => [...prev, newPreset]);
+    setLoadedPresetId(newPreset.id);
+    addToast(
+      "success",
+      t("toast.saved"),
+      `Preset "${name}" created with current dashboard.`,
+    );
+  };
+
+  const detachPreset = () => {
+    setLoadedPresetId(null);
+    addToast("info", "Detached", "Configuration is now custom.");
+  };
+
+  return {
+    activePresetName,
+    isPresetDirty,
+    loadedPresetId,
+    updateLoadedPreset,
+    revertLoadedPreset,
+    saveNewPreset,
+    detachPreset,
+  };
+}

--- a/src/hooks/useProfileImportExport.ts
+++ b/src/hooks/useProfileImportExport.ts
@@ -1,0 +1,156 @@
+import React, { useRef } from "react";
+import {
+  SerialConfig,
+  NetworkConfig,
+  SerialPreset,
+  SavedCommand,
+  SerialSequence,
+  ProjectContext,
+  Device,
+} from "../types";
+import { FileInputRef } from "../components/ui";
+import { generateId } from "../lib/utils";
+import { useStore } from "../lib/store";
+import { ExportProfileSchema } from "../lib/schemas";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Encapsulates project import/export logic extracted from ControlPanel (#81).
+ *
+ * Handles: exporting current state to JSON, importing and hydrating from file.
+ */
+export function useProfileImportExport() {
+  const { t } = useTranslation();
+  const {
+    sessions,
+    activeSessionId,
+    themeMode,
+    themeColor,
+    setThemeMode,
+    setThemeColor,
+    setConfig,
+    setNetworkConfig,
+    setPresets,
+    addToast,
+    commands,
+    sequences,
+    contexts,
+    devices,
+    presets,
+  } = useStore();
+
+  const activeSession = sessions[activeSessionId];
+  const { config, networkConfig } = activeSession;
+
+  const fileInputRef = useRef<FileInputRef>(null);
+
+  const exportProfile = () => {
+    const backup = {
+      version: "1.2.0",
+      timestamp: Date.now(),
+      appearance: { themeMode, themeColor },
+      config,
+      networkConfig,
+      presets,
+      commands,
+      sequences,
+      contexts,
+      devices,
+      logs: activeSession.logs.map((l) => ({
+        ...l,
+        data: typeof l.data === "string" ? l.data : Array.from(l.data),
+      })),
+    };
+    const blob = new Blob([JSON.stringify(backup, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `serialman-backup-${new Date().toISOString().slice(0, 10)}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    addToast("success", t("toast.success"), "Configuration saved to file.");
+  };
+
+  const importProfile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files || !e.target.files[0]) return;
+    const file = e.target.files[0];
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const content = e.target?.result as string;
+        const rawData = JSON.parse(content);
+
+        const result = ExportProfileSchema.safeParse(rawData);
+
+        if (!result.success) {
+          const errorResult = result as {
+            error: { issues: { message: string }[] };
+          };
+          console.error("Validation Errors:", errorResult.error);
+          throw new Error(
+            `Invalid file format: ${errorResult.error.issues[0].message}`,
+          );
+        }
+
+        const data = result.data;
+
+        if (data.appearance) {
+          if (data.appearance.themeMode)
+            setThemeMode(data.appearance.themeMode);
+          if (data.appearance.themeColor)
+            setThemeColor(data.appearance.themeColor);
+        }
+        if (data.config) setConfig(data.config as SerialConfig);
+        if (data.networkConfig)
+          setNetworkConfig(data.networkConfig as NetworkConfig);
+
+        if (data.presets) {
+          const validPresets: SerialPreset[] = data.presets.map((p) => ({
+            ...p,
+            config: p.config,
+          }));
+          setPresets(validPresets);
+        }
+
+        const validCommands: SavedCommand[] = (data.commands || []).map(
+          (c) => ({
+            ...c,
+            parameters: c.parameters?.map((p) => ({
+              ...p,
+              id: p.id || generateId(),
+            })),
+          }),
+        );
+
+        useStore.setState({
+          commands: validCommands,
+          sequences: (data.sequences || []) as SerialSequence[],
+          contexts: (data.contexts || []) as ProjectContext[],
+          devices: (data.devices || []) as Device[],
+        });
+
+        addToast("success", t("toast.success"), "Configuration loaded safely.");
+      } catch (err: unknown) {
+        const error = err as Error;
+        console.error(error);
+        addToast(
+          "error",
+          t("toast.error"),
+          error.message || "Invalid JSON file.",
+        );
+      }
+    };
+    reader.readAsText(file);
+    fileInputRef.current?.reset();
+  };
+
+  return {
+    fileInputRef,
+    exportProfile,
+    importProfile,
+  };
+}


### PR DESCRIPTION
## Summary

Phase 4 of the 6-phase issue resolution plan, focusing on architecture improvements.

### Changes

- **#81 - Split ControlPanel god component**: Extracted business logic into two focused hooks:
  - `usePresetOperations` — preset CRUD, dirty detection, dashboard layout application
  - `useProfileImportExport` — project export/import with Zod validation
  - ControlPanel reduced from **528 → 306 lines** (42% reduction)
- **#171 - Migrate event handling to typed-emitter**: Investigation found that Tauri events are **already fully type-safe** via `TauriEventPayloadMap` + Zod runtime validation in `src/lib/tauri/events.ts`. Removed unused `typed-emitter` and `eventemitter3` packages.
- **#101 - tauri-specta**: Assessed feasibility — implementation already exists on `feat/add-tauri-specta` branch. Recommend merging that branch separately as it involves Rust backend changes across 32 files.
- **Bonus**: Fixed pre-existing `set-state-in-effect` lint error in port refresh effect.

### Issues Addressed
- Closes #81
- Closes #171
- References #101 (deferred to existing branch `feat/add-tauri-specta`)

## Test plan

- [x] TypeScript type-check passes (`pnpm run type-check`)
- [x] ESLint passes on modified files
- [x] No new lint errors introduced
- [ ] Manual testing: verify preset save/load/revert/copy/detach still work
- [ ] Manual testing: verify project import/export still works
- [ ] Manual testing: verify serial port connection flow unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)