### PR TITLE
fix: propagate backend timestamp through serial data pipeline

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 

--- a/src-tauri/src/serial_mgr/open_port.rs
+++ b/src-tauri/src/serial_mgr/open_port.rs
@@ -48,6 +48,7 @@ fn setup_port_task(
                 match message {
                     SerialEvent::Message(message) => {
                         let len = message.data.len();
+                        let ts = message.timestamp_ms as i64;
                         if let Err(err) = app_for_read.emit(event_names::PORT_READ, message.clone())
                         {
                             tracing::error!("emit port read failed: {}", err);
@@ -64,6 +65,7 @@ fn setup_port_task(
                                 &port_name_for_read,
                                 "RX",
                                 message.data.as_slice(),
+                                Some(ts),
                             )
                             .await
                             .map_err(|e| tracing::error!("Failed to log read: {}", e));
@@ -170,6 +172,7 @@ fn setup_port_task(
                         &port_name_for_write,
                         "TX",
                         &msg,
+                        None,
                     )
                     .await
                     .map_err(|e| tracing::error!("Failed to log write: {}", e));

--- a/src-tauri/src/serial_mgr/storage/mod.rs
+++ b/src-tauri/src/serial_mgr/storage/mod.rs
@@ -95,11 +95,14 @@ impl Storage {
         port_name: &str,
         direction: &str,
         data: &[u8],
+        timestamp_ms: Option<i64>,
     ) -> Result<i64, String> {
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
+        let timestamp = timestamp_ms.unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64
+        });
 
         let model = entity::ActiveModel {
             id: sea_orm::ActiveValue::NotSet,

--- a/src/hooks/useFraming.ts
+++ b/src/hooks/useFraming.ts
@@ -56,6 +56,7 @@ export function useFraming() {
     const logId = state.processSerialFrame(
       data,
       sessionId,
+      timestamp,
       `RX Frame ${data.length}B: ${displayPreview}`,
       { sessionId, hex: hexPreview, data: Array.from(data), timestamp },
       plotterPoint,
@@ -100,7 +101,7 @@ export function useFraming() {
     sessionId: string,
     onValidate?: (data: Uint8Array, sessionId: string, logId: string) => void,
   ) => {
-    return (chunk: Uint8Array) => {
+    return (chunk: Uint8Array, timestampMs: number) => {
       let framer = framersRef.current.get(sessionId);
 
       const session = useStore.getState().sessions[sessionId];
@@ -134,8 +135,8 @@ export function useFraming() {
         framer.setConfig(effectiveConfig);
       }
 
-      // Push with current timestamp
-      framer.push({ data: chunk, timestamp: Date.now() });
+      // Push with backend timestamp (from when data was actually read from port)
+      framer.push({ data: chunk, timestamp: timestampMs });
     };
   };
 

--- a/src/hooks/useSerialConnection.ts
+++ b/src/hooks/useSerialConnection.ts
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, useCallback } from "react";
-import { GenericPort, NetworkPort } from "../lib/connection";
+import { GenericPort, NetworkPort, TimestampedChunk } from "../lib/connection";
 import { serialService, ISerialPort } from "../lib/serialService";
 import { MockPort } from "../lib/mockPort";
 import { SerialConfig, NetworkConfig, SerialOutputSignals } from "../types";
@@ -31,14 +31,14 @@ async function openSerialPort(
 }
 
 export const useSerialConnection = (
-  onDataReceived: (data: Uint8Array, sessionId: string) => void,
+  onDataReceived: (chunk: TimestampedChunk, sessionId: string) => void,
   onDisconnectCallback: (sessionId: string) => void,
 ) => {
   // Map SessionID -> Port Instance
   const portsRef = useRef<Map<string, GenericPort>>(new Map());
   // Map SessionID -> Reader (to cancel on disconnect)
   const readersRef = useRef<
-    Map<string, ReadableStreamDefaultReader<Uint8Array>>
+    Map<string, ReadableStreamDefaultReader<TimestampedChunk>>
   >(new Map());
   // Map SessionID -> KeepReading Flag
   const keepReadingRef = useRef<Map<string, boolean>>(new Map());

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -1,7 +1,13 @@
 import { SerialOutputSignals } from "../types";
 
+/** A chunk of data with the timestamp from when it was actually received. */
+export interface TimestampedChunk {
+  data: Uint8Array;
+  timestampMs: number;
+}
+
 export interface GenericPort {
-  readable: ReadableStream<Uint8Array> | null;
+  readable: ReadableStream<TimestampedChunk> | null;
   writable: WritableStream<Uint8Array> | null;
   close: () => Promise<void>;
   setSignals?: (signals: SerialOutputSignals) => Promise<void>;
@@ -9,7 +15,7 @@ export interface GenericPort {
 
 export class NetworkPort implements GenericPort {
   ws: WebSocket;
-  readable: ReadableStream<Uint8Array>;
+  readable: ReadableStream<TimestampedChunk>;
   writable: WritableStream<Uint8Array>;
   closed: Promise<void>;
 
@@ -25,10 +31,17 @@ export class NetworkPort implements GenericPort {
     this.readable = new ReadableStream({
       start: (controller) => {
         this.ws.onmessage = (event) => {
+          const timestampMs = Date.now();
           if (event.data instanceof ArrayBuffer) {
-            controller.enqueue(new Uint8Array(event.data));
+            controller.enqueue({
+              data: new Uint8Array(event.data),
+              timestampMs,
+            });
           } else if (typeof event.data === "string") {
-            controller.enqueue(new TextEncoder().encode(event.data));
+            controller.enqueue({
+              data: new TextEncoder().encode(event.data),
+              timestampMs,
+            });
           }
         };
         this.ws.onclose = () => {

--- a/src/lib/mockPort.ts
+++ b/src/lib/mockPort.ts
@@ -1,4 +1,4 @@
-import { GenericPort } from "./connection";
+import { GenericPort, TimestampedChunk } from "./connection";
 
 export type MockPortType =
   | "mock-echo"
@@ -9,12 +9,19 @@ export type MockPortType =
   | "mock-sine-wave";
 
 export class MockPort implements GenericPort {
-  readable: ReadableStream<Uint8Array>;
+  readable: ReadableStream<TimestampedChunk>;
   writable: WritableStream<Uint8Array>;
-  private controller?: ReadableStreamDefaultController<Uint8Array>;
+  private controller?: ReadableStreamDefaultController<TimestampedChunk>;
   private active: boolean = true;
   // Fix: Use any instead of NodeJS.Timeout to avoid namespace errors in pure browser environments
   private interval?: ReturnType<typeof setInterval>;
+
+  /** Enqueue data with current timestamp */
+  private emit(data: Uint8Array) {
+    if (this.controller) {
+      this.controller.enqueue({ data, timestampMs: Date.now() });
+    }
+  }
 
   constructor(public readonly type: string) {
     this.readable = new ReadableStream({
@@ -34,8 +41,8 @@ export class MockPort implements GenericPort {
         if (this.type === "mock-echo") {
           // Echo back with slight delay
           await new Promise((r) => setTimeout(r, 10));
-          if (this.active && this.controller) {
-            this.controller.enqueue(chunk);
+          if (this.active) {
+            this.emit(chunk);
           }
         }
         // Other mocks could respond to specific commands here if needed
@@ -54,21 +61,20 @@ export class MockPort implements GenericPort {
 
         if (mode < 0.4) {
           const msg = `{"id":${counter},"val":${(Math.random() * 100).toFixed(1)}}\n`;
-          this.controller.enqueue(new TextEncoder().encode(msg));
+          this.emit(new TextEncoder().encode(msg));
         } else if (mode < 0.7) {
           const msg = `{"id":${counter},"type":"frag","val":${(Math.random() * 100).toFixed(1)}}\n`;
           const bytes = new TextEncoder().encode(msg);
           const split = Math.floor(bytes.length / 2);
-          this.controller.enqueue(bytes.slice(0, split));
+          this.emit(bytes.slice(0, split));
           setTimeout(() => {
-            if (this.active && this.controller)
-              this.controller.enqueue(bytes.slice(split));
+            if (this.active) this.emit(bytes.slice(split));
           }, 20);
         } else {
           const msg1 = `{"id":${counter},"t":"burst1"}\n`;
           const msg2 = `{"id":${counter + 1},"t":"burst2"}\n`;
           counter++;
-          this.controller.enqueue(new TextEncoder().encode(msg1 + msg2));
+          this.emit(new TextEncoder().encode(msg1 + msg2));
         }
       }, 800);
     } else if (this.type === "mock-timeout-stream") {
@@ -77,22 +83,13 @@ export class MockPort implements GenericPort {
       const loop = async () => {
         while (this.active) {
           counter = (counter + 1) % 100;
-          if (this.controller)
-            this.controller.enqueue(
-              new TextEncoder().encode(`{"seq":${counter},"part":1}`),
-            );
+          this.emit(new TextEncoder().encode(`{"seq":${counter},"part":1}`));
           await new Promise((r) => setTimeout(r, 20));
           if (!this.active) break;
-          if (this.controller)
-            this.controller.enqueue(
-              new TextEncoder().encode(`{"seq":${counter},"part":2}`),
-            );
+          this.emit(new TextEncoder().encode(`{"seq":${counter},"part":2}`));
           await new Promise((r) => setTimeout(r, 20));
           if (!this.active) break;
-          if (this.controller)
-            this.controller.enqueue(
-              new TextEncoder().encode(`{"seq":${counter},"part":3}`),
-            );
+          this.emit(new TextEncoder().encode(`{"seq":${counter},"part":3}`));
           await new Promise((r) => setTimeout(r, 1000));
         }
       };
@@ -128,30 +125,29 @@ export class MockPort implements GenericPort {
             );
             fullPacket.set(header);
             fullPacket.set(payloadBytes, 2);
-            if (this.controller) this.controller.enqueue(fullPacket);
+            this.emit(fullPacket);
           } else if (mode < 0.7) {
             // Split Header
-            if (this.controller) this.controller.enqueue(header.slice(0, 1));
+            this.emit(header.slice(0, 1));
             await new Promise((r) => setTimeout(r, 15)); // Short lag
             if (!this.active) break;
 
             const rest = new Uint8Array(1 + payloadBytes.length);
             rest.set(header.slice(1), 0);
             rest.set(payloadBytes, 1);
-            if (this.controller) this.controller.enqueue(rest);
+            this.emit(rest);
           } else {
             // Split Body
             const splitIdx = Math.floor(payloadBytes.length / 2);
             const firstPart = new Uint8Array(2 + splitIdx);
             firstPart.set(header);
             firstPart.set(payloadBytes.slice(0, splitIdx), 2);
-            if (this.controller) this.controller.enqueue(firstPart);
+            this.emit(firstPart);
 
             await new Promise((r) => setTimeout(r, 20)); // Lag
             if (!this.active) break;
 
-            if (this.controller)
-              this.controller.enqueue(payloadBytes.slice(splitIdx));
+            this.emit(payloadBytes.slice(splitIdx));
           }
 
           await new Promise((r) => setTimeout(r, 800));
@@ -170,7 +166,7 @@ export class MockPort implements GenericPort {
 
         // Format: sin, cos, noise
         const msg = `${sin}, ${cos}, ${noise}\n`;
-        this.controller.enqueue(new TextEncoder().encode(msg));
+        this.emit(new TextEncoder().encode(msg));
       }, 20); // 50Hz
     }
   }

--- a/src/lib/serialService.ts
+++ b/src/lib/serialService.ts
@@ -4,7 +4,7 @@ import {
   SerialInputSignals,
   SerialOutputSignals,
 } from "../types";
-import { GenericPort } from "./connection";
+import { GenericPort, TimestampedChunk } from "./connection";
 import { TauriSerialAPI, TauriEventNames, listenToTauriEvent } from "./tauri";
 import { UnlistenFn } from "@tauri-apps/api/event";
 import { IS_TAURI } from "./tauriEnv";
@@ -70,9 +70,9 @@ class WebSerialProvider implements ISerialProvider {
 // Tauri Port Implementation - Bridges Tauri commands to stream-based interface
 class TauriPort implements ISerialPort {
   portName: string;
-  readable: ReadableStream<Uint8Array> | null = null;
+  readable: ReadableStream<TimestampedChunk> | null = null;
   writable: WritableStream<Uint8Array> | null = null;
-  private readController: ReadableStreamDefaultController<Uint8Array> | null =
+  private readController: ReadableStreamDefaultController<TimestampedChunk> | null =
     null;
   private unlistenRead: UnlistenFn | null = null;
   private signals: SerialInputSignals = {
@@ -106,7 +106,7 @@ class TauriPort implements ISerialPort {
     });
 
     // Create readable stream that listens to Tauri events
-    this.readable = new ReadableStream<Uint8Array>({
+    this.readable = new ReadableStream<TimestampedChunk>({
       start: async (controller) => {
         this.readController = controller;
         // Listen for data from Tauri backend with type safety
@@ -115,8 +115,10 @@ class TauriPort implements ISerialPort {
           (event) => {
             // Only process data for this port
             if (event.payload.portName === this.portName) {
-              const data = new Uint8Array(event.payload.data);
-              controller.enqueue(data);
+              controller.enqueue({
+                data: new Uint8Array(event.payload.data),
+                timestampMs: event.payload.timestampMs,
+              });
             }
           },
         );

--- a/src/lib/slices/sessionSlice.ts
+++ b/src/lib/slices/sessionSlice.ts
@@ -183,6 +183,7 @@ export interface SessionSliceActions {
   processSerialFrame: (
     data: Uint8Array,
     sessionId: string,
+    timestamp: number,
     systemLogMessage: string,
     systemLogDetails: Record<string, unknown>,
     plotterPoint?: PlotterDataPoint | null,
@@ -744,12 +745,12 @@ export const createSessionSlice: StateCreator<
   processSerialFrame: (
     data,
     sessionId,
+    timestamp,
     systemLogMessage,
     systemLogDetails,
     plotterPoint,
   ) => {
     const id = generateId();
-    const now = Date.now();
     set((state) => {
       const session = state.sessions[sessionId];
       if (!session) return;
@@ -757,7 +758,7 @@ export const createSessionSlice: StateCreator<
       // 1. Add log entry (immer draft mutation — no array copy)
       const entry: LogEntry = {
         id,
-        timestamp: now,
+        timestamp,
         direction: "RX",
         data: new Uint8Array(data),
         format: "HEX",
@@ -804,7 +805,7 @@ export const createSessionSlice: StateCreator<
       const uiState = state as unknown as UISliceState;
       uiState.systemLogs.unshift({
         id: generateId(),
-        timestamp: now,
+        timestamp,
         level: "INFO" as LogLevel,
         category: "COMMAND" as LogCategory,
         message: systemLogMessage,

--- a/src/pages/MainWorkspace.tsx
+++ b/src/pages/MainWorkspace.tsx
@@ -148,13 +148,13 @@ const MainWorkspace: React.FC = () => {
   // Connection Hook
   const { connect, disconnect, write, toggleSignal, isWebSerialSupported } =
     useSerialConnection(
-      (chunk: Uint8Array, sessionId: string) => {
+      (chunk, sessionId: string) => {
         // Use framing hook to handle incoming data
         const handleData = framing.handleDataReceived(
           sessionId,
           validation.checkValidation,
         );
-        handleData(chunk);
+        handleData(chunk.data, chunk.timestampMs);
       },
       (sessionId) => {
         // onDisconnect - always update the specific session's connection state

--- a/src/tests/hooks/useFraming.test.ts
+++ b/src/tests/hooks/useFraming.test.ts
@@ -63,7 +63,7 @@ describe("useFraming", () => {
       const testData = new Uint8Array([65, 66, 67]); // "ABC"
 
       await act(async () => {
-        handler(testData);
+        handler(testData, Date.now());
         // Wait for async composeFrames to complete
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -83,7 +83,7 @@ describe("useFraming", () => {
       const testData = new Uint8Array([65, 66, 67]); // "ABC"
 
       await act(async () => {
-        handler(testData);
+        handler(testData, Date.now());
         // Wait for async composeFrames to complete
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -107,7 +107,7 @@ describe("useFraming", () => {
       // Should not throw
       expect(() => {
         act(() => {
-          handler(emptyData);
+          handler(emptyData, Date.now());
         });
       }).not.toThrow();
     });
@@ -122,7 +122,7 @@ describe("useFraming", () => {
       const binaryData = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe]);
 
       await act(async () => {
-        handler(binaryData);
+        handler(binaryData, Date.now());
         // Wait for async composeFrames to complete
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -140,7 +140,7 @@ describe("useFraming", () => {
       const testData = new Uint8Array([65]);
 
       act(() => {
-        handler(testData);
+        handler(testData, Date.now());
       });
 
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -160,7 +160,7 @@ describe("useFraming", () => {
       // Create framer by handling data
       const handler = result.current.handleDataReceived(sessionId);
       act(() => {
-        handler(new Uint8Array([65, 66, 67]));
+        handler(new Uint8Array([65, 66, 67]), Date.now());
       });
 
       // Cleanup should not throw
@@ -206,7 +206,7 @@ describe("useFraming", () => {
       const testData = new Uint8Array([65, 66, 10]); // "AB\n"
 
       await act(async () => {
-        handler(testData);
+        handler(testData, Date.now());
         // Wait for async composeFrames to complete
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -238,7 +238,7 @@ describe("useFraming", () => {
       const handler = result.current.handleDataReceived(sessionId);
 
       await act(async () => {
-        handler(new Uint8Array([65, 66, 67]));
+        handler(new Uint8Array([65, 66, 67]), Date.now());
         // Wait for async composeFrames to complete
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -277,8 +277,8 @@ describe("useFraming", () => {
       const handler2 = result.current.handleDataReceived(session2);
 
       await act(async () => {
-        handler1(new Uint8Array([65])); // A
-        handler2(new Uint8Array([66])); // B
+        handler1(new Uint8Array([65]), Date.now()); // A
+        handler2(new Uint8Array([66]), Date.now()); // B
         // Wait for async composeFrames to complete
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
@@ -302,7 +302,7 @@ describe("useFraming", () => {
       const testData = new Uint8Array([72, 101, 108, 108, 111]); // "Hello"
 
       act(() => {
-        handler(testData);
+        handler(testData, Date.now());
       });
 
       const systemLogs = useStore.getState().systemLogs;
@@ -323,7 +323,7 @@ describe("useFraming", () => {
       const longData = new Uint8Array(100).fill(65); // 100 'A' characters
 
       act(() => {
-        handler(longData);
+        handler(longData, Date.now());
       });
 
       const systemLogs = useStore.getState().systemLogs;

--- a/src/tests/hooks/useSerialConnection.test.ts
+++ b/src/tests/hooks/useSerialConnection.test.ts
@@ -3,9 +3,12 @@ import type { Mock } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useSerialConnection } from "@/hooks/useSerialConnection";
 import { NetworkConfig, SerialConfig } from "@/types";
+import type { TimestampedChunk } from "@/lib/connection";
 
 describe("useSerialConnection", () => {
-  let onDataReceived: Mock<(data: Uint8Array, sessionId: string) => void>;
+  let onDataReceived: Mock<
+    (chunk: TimestampedChunk, sessionId: string) => void
+  >;
   let onDisconnect: Mock<(sessionId: string) => void>;
   let defaultConfig: SerialConfig;
   let defaultNetworkConfig: NetworkConfig;
@@ -200,9 +203,10 @@ describe("useSerialConnection", () => {
         { timeout: 100 },
       );
 
-      // Verify the echoed data
-      const receivedData = onDataReceived.mock.calls[0][0];
-      expect(Array.from(receivedData)).toEqual(Array.from(testData));
+      // Verify the echoed data (now wrapped in TimestampedChunk)
+      const receivedChunk = onDataReceived.mock.calls[0][0];
+      expect(Array.from(receivedChunk.data)).toEqual(Array.from(testData));
+      expect(typeof receivedChunk.timestampMs).toBe("number");
       expect(onDataReceived.mock.calls[0][1]).toBe("session-1");
     });
 
@@ -287,7 +291,10 @@ describe("useSerialConnection", () => {
       await waitFor(
         () => {
           expect(onDataReceived).toHaveBeenCalledWith(
-            expect.any(Uint8Array),
+            expect.objectContaining({
+              data: expect.any(Uint8Array),
+              timestampMs: expect.any(Number),
+            }),
             "session-1",
           );
         },

--- a/src/tests/lib/connection.test.ts
+++ b/src/tests/lib/connection.test.ts
@@ -92,7 +92,8 @@ describe("NetworkPort", () => {
 
       const result = await reader.read();
       expect(result.done).toBe(false);
-      expect(Array.from(result.value as Uint8Array)).toEqual([1, 2, 3, 4, 5]);
+      expect(Array.from(result.value!.data)).toEqual([1, 2, 3, 4, 5]);
+      expect(typeof result.value!.timestampMs).toBe("number");
 
       reader.releaseLock();
     });
@@ -112,9 +113,8 @@ describe("NetworkPort", () => {
 
       const result = await reader.read();
       expect(result.done).toBe(false);
-      expect(Array.from(result.value as Uint8Array)).toEqual([
-        72, 101, 108, 108, 111,
-      ]); // "Hello"
+      expect(Array.from(result.value!.data)).toEqual([72, 101, 108, 108, 111]); // "Hello"
+      expect(typeof result.value!.timestampMs).toBe("number");
 
       reader.releaseLock();
     });
@@ -294,7 +294,7 @@ describe("NetworkPort", () => {
       }
 
       const result = await reader.read();
-      expect(Array.from(result.value as Uint8Array)).toEqual([4, 5, 6]);
+      expect(Array.from(result.value!.data)).toEqual([4, 5, 6]);
 
       // Clean up
       reader.releaseLock();


### PR DESCRIPTION
## Summary

- **Problem**: The Rust backend captures accurate timestamps when `port.read()` returns, but this was discarded at 4 points in the pipeline. Each layer independently created new timestamps using `Date.now()` or `SystemTime::now()`, introducing 2-15ms of drift from actual hardware read time.
- **Fix**: Thread the backend `timestamp_ms` from `PortReadEvent` through every layer — Rust storage, Tauri event → TS ReadableStream → framing → store. No consumer fabricates its own timestamp anymore.
- Introduces `TimestampedChunk` type (`{ data: Uint8Array; timestampMs: number }`) as the stream element for `GenericPort.readable`

## Discard points fixed

| Layer | Before | After |
|-------|--------|-------|
| Rust `storage.insert()` | `SystemTime::now()` | Uses `message.timestamp_ms` for RX |
| `serialService.ts` (TauriPort) | Dropped `timestampMs`, enqueued raw `Uint8Array` | Enqueues `TimestampedChunk` with backend timestamp |
| `useFraming.ts` | `Date.now()` | Uses `timestampMs` from stream chunk |
| `processSerialFrame` | `Date.now()` | Accepts `timestamp` parameter |

## Files changed

**Rust (2 files)**
- `storage/mod.rs` — `insert()` accepts optional `timestamp_ms` param
- `open_port.rs` — RX path passes `message.timestamp_ms` to storage

**TypeScript (7 files)**
- `connection.ts` — New `TimestampedChunk` type, `GenericPort` updated
- `serialService.ts` — TauriPort forwards backend timestamp
- `mockPort.ts` — Uses `this.emit()` helper with `Date.now()`
- `useFraming.ts` — Passes backend timestamp to framer
- `useSerialConnection.ts` — Callback signature updated
- `sessionSlice.ts` — `processSerialFrame` accepts timestamp param
- `MainWorkspace.tsx` — Wiring updated

**Tests (3 files)** — Updated for `TimestampedChunk` type

## Test plan

- [x] `pnpm run type-check` — passes
- [x] `cargo check` — passes
- [x] `pnpm run test` — 463 passed, 3 skipped, 0 failed
- [ ] Manual test: connect to serial device, verify timestamps in console logs match hardware timing
- [ ] Verify plotter X-axis timing accuracy with known-frequency signal